### PR TITLE
fix scan number to work with percolator on windows.

### DIFF
--- a/spectrum_fundamentals/metrics/percolator.py
+++ b/spectrum_fundamentals/metrics/percolator.py
@@ -147,7 +147,7 @@ class Percolator(Metric):
         """
         raw_file, scan_number = metadata_subset
         s = f"{raw_file}{scan_number}".encode()
-        return int(hashlib.sha224(s).hexdigest()[:12], 16)
+        return int(hashlib.sha224(s).hexdigest()[:6], 16)
 
     @staticmethod
     def get_delta_score(scores_df: pd.DataFrame, scoring_feature: str) -> np.ndarray:

--- a/spectrum_fundamentals/metrics/percolator.py
+++ b/spectrum_fundamentals/metrics/percolator.py
@@ -378,7 +378,7 @@ class Percolator(Metric):
 
         np.random.seed(1)
         # add Prosit or Andromeda features
-        if self.input_type == "prosit":
+        if self.input_type == "rescore":
             fragments_ratio = fr.FragmentsRatio(self.pred_intensities, self.true_intensities)
             fragments_ratio.calc()
 
@@ -427,7 +427,7 @@ class Percolator(Metric):
             self.metrics_val["andromeda"] = self.metadata["SCORE"]
 
         self.add_percolator_metadata_columns()
-        if self.input_type == "prosit":
+        if self.input_type == "rescore":
             # TODO: only add this feature if they are not all zero
             # self.metrics_val['spectral_angle_delta_score'] = Percolator.get_delta_score(self.metrics_val[['ScanNr',
             # 'spectral_angle']], 'spectral_angle')

--- a/tests/unit_tests/test_percolator.py
+++ b/tests/unit_tests/test_percolator.py
@@ -163,7 +163,7 @@ class TestPercolator:
     def test_get_scannr(self):
         """Test get_scannr."""
         np.testing.assert_equal(
-            perc.Percolator.get_scannr(("20210122_0263_TMUCLHan_Peiru_DDA_IP_C797S_02", 7978)), 171184297275363
+            perc.Percolator.get_scannr(("20210122_0263_TMUCLHan_Peiru_DDA_IP_C797S_02", 7978)), 10203379
         )
 
     def test_get_specid(self):

--- a/tests/unit_tests/test_percolator.py
+++ b/tests/unit_tests/test_percolator.py
@@ -20,7 +20,7 @@ class TestFdrs:
 
     def test_get_indices_below_fdr_none(self):
         """Test get_indices_below_fdr."""
-        percolator = perc.Percolator(metadata=pd.DataFrame(), input_type="prosit")
+        percolator = perc.Percolator(metadata=pd.DataFrame(), input_type="rescore")
         percolator.metrics_val["Score"] = [0, 3, 2, 1]
         percolator.target_decoy_labels = [-1, -1, 1, -1]
         """
@@ -34,7 +34,7 @@ class TestFdrs:
 
     def test_get_indices_below_fdr_unordered_idxs(self):
         """Test get_indices_below_fdr."""
-        percolator = perc.Percolator(metadata=pd.DataFrame(), input_type="prosit")
+        percolator = perc.Percolator(metadata=pd.DataFrame(), input_type="rescore")
         percolator.metrics_val["Score"] = [0, 3, 2, 1, -1]
         percolator.target_decoy_labels = [-1, 1, 1, -1, 1]
 
@@ -52,7 +52,7 @@ class TestFdrs:
 
     def test_get_indices_below_fdr(self):
         """Test get_indices_below_fdr."""
-        percolator = perc.Percolator(metadata=pd.DataFrame(), input_type="prosit")
+        percolator = perc.Percolator(metadata=pd.DataFrame(), input_type="rescore")
         percolator.metrics_val["Score"] = [0, 3, 2, 1]
         percolator.target_decoy_labels = [-1, 1, 1, -1]
         """
@@ -66,7 +66,7 @@ class TestFdrs:
 
     def test_get_indices_below_fdr_filter_decoy(self):
         """Test get_indices_below_fdr."""
-        percolator = perc.Percolator(metadata=pd.DataFrame(), input_type="prosit")
+        percolator = perc.Percolator(metadata=pd.DataFrame(), input_type="rescore")
         percolator.metrics_val["Score"] = [0, 3, 2, 1, 4, 5, 6, 7]
         percolator.target_decoy_labels = [-1, 1, 1, -1, -1, 1, 1, 1]
         """
@@ -88,7 +88,7 @@ class TestLda:
 
     def test_apply_lda_and_get_indices_below_fdr(self):
         """Score_2 adds more discriminative power between targets and decoys."""
-        percolator = perc.Percolator(metadata=pd.DataFrame(), input_type="prosit")
+        percolator = perc.Percolator(metadata=pd.DataFrame(), input_type="rescore")
         percolator.metrics_val["Score"] = [0.0, 3.0, 2.0, 1.0, 4.0, 5.0, 6.0, 7.0]
         percolator.metrics_val["Score_2"] = [1.0, 1.5, 2.0, 1.5, 1.0, 1.5, 2.0, 1.5]
         percolator.target_decoy_labels = np.array([-1, 1, 1, -1, -1, 1, 1, 1])
@@ -333,7 +333,7 @@ class TestPercolator:
 
         percolator = perc.Percolator(
             metadata=perc_input,
-            input_type="prosit",
+            input_type="rescore",
             pred_intensities=predicted_intensities,
             true_intensities=observed_intensities,
             fdr_cutoff=0.4,

--- a/tests/unit_tests/test_percolator.py
+++ b/tests/unit_tests/test_percolator.py
@@ -345,7 +345,7 @@ class TestPercolator:
             percolator.metrics_val["SpecId"][0], "20210122_0263_TMUCLHan_Peiru_DDA_IP_C797S_02-7978-AAIGEATRL-2-1"
         )
         np.testing.assert_equal(percolator.metrics_val["Label"][0], 1)
-        np.testing.assert_equal(percolator.metrics_val["ScanNr"][0], 171184297275363)
+        np.testing.assert_equal(percolator.metrics_val["ScanNr"][0], 10203379)
         # np.testing.assert_almost_equal(percolator.metrics_val['ExpMass'][0], 900.50345678)
         np.testing.assert_string_equal(percolator.metrics_val["Peptide"][0], "_.AAIGEATRL._")
         np.testing.assert_string_equal(


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] This comment contains a description of changes (with reason)
-   [ ] Referenced issue is linked
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**

- Changed the scan number for the percolator to use fewer bits to work with windows users.
- Changed all the flags from prosit to rescore as the pipeline should work with different models not just prosit.

**Technical details**

<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->

**Additional context**

<!-- Add any other context or screenshots here. -->
