### PR TITLE
Pluggable peak-match resolvers (nearest, global_ransac, dp_ladder, dp_calibrated)

### DIFF
--- a/spectrum_fundamentals/annotation/annotation.py
+++ b/spectrum_fundamentals/annotation/annotation.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 from spectrum_fundamentals import constants
+from spectrum_fundamentals.annotation.matchers import resolve_matches
 from spectrum_fundamentals.fragments import (
     initialize_peaks,
     initialize_peaks_xl,
@@ -161,6 +162,8 @@ def annotate_spectra(
     p_window: float = 0.0,
     annotate_neutral_loss: bool = False,
     featured_ions: list[str] | None = None,
+    matching_method: str = "nearest",
+    matching_method_params: dict | None = None,
 ) -> pd.DataFrame:
     """
     Annotate a set of spectra.
@@ -186,6 +189,12 @@ def annotate_spectra(
     :param custom_mods: mapping of custom UNIMOD string identifiers ('[UNIMOD:xyz]') to their mass
     :param annotate_neutral_loss: flag to indicate whether to annotate neutral losses or not
     :param featured_ions: list of featured ions to annotate
+    :param matching_method: name of the candidate-resolver registered in ``annotation.matchers``.
+        Defaults to ``"nearest"`` (legacy closest-m/z behaviour). Only used by the linear path;
+        the cross-link path always uses the legacy resolver.
+    :param matching_method_params: optional keyword arguments forwarded to the resolver
+        (e.g. ``{"unique_peak": False, "residual_threshold_ppm": 8}`` for ``global_ransac``).
+        Ignored by resolvers that don't accept them.
     :return: a Pandas DataFrame containing the annotated spectra with meta data
     """
     raw_file_annotations = []
@@ -205,6 +214,8 @@ def annotate_spectra(
             custom_mods=custom_mods,
             annotate_neutral_losses=annotate_neutral_loss,
             featured_ions=featured_ions,
+            matching_method=matching_method,
+            matching_method_params=matching_method_params,
         )
         if not results:
             continue
@@ -438,6 +449,8 @@ def parallel_annotate(
     featured_ions: list[str] | None = None,
     p_window: float = 0.0,
     annotate_neutral_losses: bool = False,
+    matching_method: str = "nearest",
+    matching_method_params: dict | None = None,
 ) -> (
     tuple[np.ndarray, np.ndarray, float, int, int, int]
     | tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, float, float, int, int]
@@ -464,6 +477,8 @@ def parallel_annotate(
     :param featured_ions: list of ions to be annotated
     :param p_window: peak exclusion window for multifrag, dedicated to remove precursor peaks (da)
     :param annotate_neutral_losses: flag to indicate whether to annotate neutral losses or not
+    :param matching_method: name of the candidate-resolver registered in ``annotation.matchers``.
+    :param matching_method_params: optional keyword arguments forwarded to the resolver.
     :return: a tuple containing intensity values (np.ndarray), masses (np.ndarray), calculated mass (float),
              and any removed peaks (List[str])
     """
@@ -482,6 +497,8 @@ def parallel_annotate(
             custom_mods=custom_mods,
             add_neutral_losses=annotate_neutral_losses,
             featured_ions=featured_ions,
+            matching_method=matching_method,
+            matching_method_params=matching_method_params,
         )
 
     if (spectrum[index_columns["PEPTIDE_LENGTH_A"]] > 30) or (spectrum[index_columns["PEPTIDE_LENGTH_B"]] > 30):
@@ -502,6 +519,8 @@ def _annotate_linear_spectrum(
     multifrag: bool = False,
     p_window: float = 0.0,
     add_neutral_losses: bool = False,
+    matching_method: str = "nearest",
+    matching_method_params: dict | None = None,
 ):
     """
     Annotate a linear peptide spectrum.
@@ -516,6 +535,11 @@ def _annotate_linear_spectrum(
     :param multifrag: flag to indicate whether to annotate multifrag or not
     :param featured_ions: list of ions to be annotated
     :param p_window: peak exclusion window for multifrag, dedicated to remove precursor peaks (da)
+    :param matching_method: name of the resolver in ``annotation.matchers`` to use for
+        collapsing candidate matches to one peak per fragment slot. Defaults to ``"nearest"``,
+        which reproduces the legacy ``handle_multiple_matches(sort_by="mass_diff")`` behaviour.
+    :param matching_method_params: optional keyword arguments forwarded to the resolver. These
+        take precedence over the mass-tolerance values passed automatically (see below).
     :return: Annotated spectrum
     """
     mod_seq_column = "MODIFIED_SEQUENCE"
@@ -561,7 +585,23 @@ def _annotate_linear_spectrum(
         mass = np.full(vec_length, 0.0)
         return intensity, mass, calc_mass, 0, 0, 0
 
-    matched_peaks, removed_peaks = handle_multiple_matches(matched_peaks)
+    # Pass the matching tolerance so tolerance-aware resolvers (e.g. global_ransac)
+    # can scale their inlier band to the instrument. Explicit matching_method_params
+    # win on key collisions.
+    resolver_kwargs: dict = {
+        "mass_tolerance": mass_tolerance,
+        "unit_mass_tolerance": unit_mass_tolerance,
+    }
+    if matching_method_params:
+        resolver_kwargs.update(matching_method_params)
+    matched_peaks, removed_peaks = resolve_matches(
+        method=matching_method,
+        candidates=matched_peaks,
+        peaks_masses=spectrum[index_columns["MZ"]],
+        peaks_intensity=spectrum[index_columns["INTENSITIES"]],
+        unmod_sequence=unmod_sequence,
+        **resolver_kwargs,
+    )
     intensities, mass = generate_annotation_matrix(
         matched_peaks,
         unmod_sequence,

--- a/spectrum_fundamentals/annotation/annotation.py
+++ b/spectrum_fundamentals/annotation/annotation.py
@@ -230,6 +230,7 @@ def annotate_spectra(
             "removed_peaks",
             "ANNOTATED_NL_COUNT",
             "EXPECTED_NL_COUNT",
+            "sc_features",
         ]
     else:
         results_df.columns = [
@@ -452,7 +453,7 @@ def parallel_annotate(
     matching_method: str = "nearest",
     matching_method_params: dict | None = None,
 ) -> (
-    tuple[np.ndarray, np.ndarray, float, int, int, int]
+    tuple[np.ndarray, np.ndarray, float, int, int, int, dict]
     | tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, float, float, int, int]
     | None
 ):
@@ -479,8 +480,10 @@ def parallel_annotate(
     :param annotate_neutral_losses: flag to indicate whether to annotate neutral losses or not
     :param matching_method: name of the candidate-resolver registered in ``annotation.matchers``.
     :param matching_method_params: optional keyword arguments forwarded to the resolver.
-    :return: a tuple containing intensity values (np.ndarray), masses (np.ndarray), calculated mass (float),
-             and any removed peaks (List[str])
+    :return: a tuple containing intensity values (np.ndarray), masses (np.ndarray),
+         calculated mass (float), removed peaks (int), annotated NL count (int),
+         expected NL count (int), mean_ppm_error (float), max_ppm_error (float),
+         std_ppm_error (float)
     """
     xl_type_col = index_columns.get("CROSSLINKER_TYPE")
     if xl_type_col is None:
@@ -583,7 +586,12 @@ def _annotate_linear_spectrum(
     if len(matched_peaks) == 0:
         intensity = np.full(vec_length, 0.0)
         mass = np.full(vec_length, 0.0)
-        return intensity, mass, calc_mass, 0, 0, 0
+        sc_features = {
+            "mean_ppm_error": float("nan"),
+            "max_ppm_error": float("nan"),
+            "std_ppm_error": float("nan"),
+        } #nan for ppm_error values
+        return intensity, mass, calc_mass, 0, 0, 0, sc_features
 
     # Pass the matching tolerance so tolerance-aware resolvers (e.g. global_ransac)
     # can scale their inlier band to the instrument. Explicit matching_method_params
@@ -602,6 +610,27 @@ def _annotate_linear_spectrum(
         unmod_sequence=unmod_sequence,
         **resolver_kwargs,
     )
+
+    # Extract ppm_error summary stats before generate_annotation_matrix()
+    # discards the matched_peaks DataFrame. These are passed up the call
+    # chain and stored in the Spectra object for use as Percolator features.
+    if "ppm_error" in matched_peaks.columns and len(matched_peaks) > 0:
+        # sc_features: extensible dict for single-cell rescoring features.
+        # Add new per-PSM scalar features here as needed.
+        sc_features = {
+            "mean_ppm_error": float(matched_peaks["ppm_error"].mean()),
+            "max_ppm_error": float(matched_peaks["ppm_error"].max()),
+            "std_ppm_error": float(matched_peaks["ppm_error"].std(ddof=0)),
+        }
+    else:
+        # NaN signals missing data, not a perfect match (0.0 would be misleading).
+        # TODO: handle NaN downstream in percolator.py before passing to Percolator.
+        sc_features = {
+            "mean_ppm_error": float("nan"),
+            "max_ppm_error": float("nan"),
+            "std_ppm_error": float("nan"),
+        }
+
     intensities, mass = generate_annotation_matrix(
         matched_peaks,
         unmod_sequence,
@@ -610,7 +639,7 @@ def _annotate_linear_spectrum(
         multifrag=multifrag,
         featured_ions=featured_ions,
     )
-    return intensities, mass, calc_mass, removed_peaks, count_annotated_nl, expected_nl
+    return intensities, mass, calc_mass, removed_peaks, count_annotated_nl, expected_nl, sc_features
 
 
 def _annotate_crosslinked_spectrum(

--- a/spectrum_fundamentals/annotation/annotation.py
+++ b/spectrum_fundamentals/annotation/annotation.py
@@ -590,7 +590,7 @@ def _annotate_linear_spectrum(
             "mean_ppm_error": float("nan"),
             "max_ppm_error": float("nan"),
             "std_ppm_error": float("nan"),
-        } #nan for ppm_error values
+        }  # nan for ppm_error values
         return intensity, mass, calc_mass, 0, 0, 0, sc_features
 
     # Pass the matching tolerance so tolerance-aware resolvers (e.g. global_ransac)

--- a/spectrum_fundamentals/annotation/matchers/__init__.py
+++ b/spectrum_fundamentals/annotation/matchers/__init__.py
@@ -1,0 +1,61 @@
+"""Peak match resolvers.
+
+A resolver collapses the candidate list returned by ``match_peaks`` (zero or
+more observed peaks per theoretical fragment, all already inside the ppm
+tolerance window) into one matched peak per fragment slot — i.e. one row per
+``(ion_type, no, charge)``.
+
+Resolver signature::
+
+    resolver(
+        candidates: list[dict],
+        peaks_masses: np.ndarray,
+        peaks_intensity: np.ndarray,
+        unmod_sequence: str,
+        **kwargs,
+    ) -> tuple[pd.DataFrame, int]
+
+Returns ``(matched_peaks_df, n_dropped)``. The DataFrame must contain the
+columns consumed downstream by ``generate_annotation_matrix``:
+``ion_type, no, charge, exp_mass, theoretical_mass, intensity`` (plus
+``full_name`` when ``multifrag=True``).
+"""
+
+from collections.abc import Callable
+
+import numpy as np
+import pandas as pd
+
+from .global_ransac import global_ransac_resolver
+from .nearest import nearest_resolver
+
+Resolver = Callable[..., tuple[pd.DataFrame, int]]
+
+MATCHERS: dict[str, Resolver] = {
+    "nearest": nearest_resolver,
+    "global_ransac": global_ransac_resolver,
+}
+
+
+def resolve_matches(
+    method: str,
+    candidates: list[dict],
+    peaks_masses: np.ndarray,
+    peaks_intensity: np.ndarray,
+    unmod_sequence: str,
+    **kwargs,
+) -> tuple[pd.DataFrame, int]:
+    """Dispatch candidate-list resolution to the named matcher."""
+    try:
+        resolver = MATCHERS[method]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown matching_method '{method}'. Available: {sorted(MATCHERS)}"
+        ) from exc
+    return resolver(
+        candidates=candidates,
+        peaks_masses=peaks_masses,
+        peaks_intensity=peaks_intensity,
+        unmod_sequence=unmod_sequence,
+        **kwargs,
+    )

--- a/spectrum_fundamentals/annotation/matchers/__init__.py
+++ b/spectrum_fundamentals/annotation/matchers/__init__.py
@@ -17,7 +17,7 @@ Resolver signature::
 
 Returns ``(matched_peaks_df, n_dropped)``. The DataFrame must contain the
 columns consumed downstream by ``generate_annotation_matrix``:
-``ion_type, no, charge, exp_mass, theoretical_mass, intensity`` (plus
+``ion_type, no, charge, exp_mass, theoretical_mass, intensity, ppm_error (optional)`` (plus
 ``full_name`` when ``multifrag=True``).
 """
 

--- a/spectrum_fundamentals/annotation/matchers/__init__.py
+++ b/spectrum_fundamentals/annotation/matchers/__init__.py
@@ -26,6 +26,8 @@ from collections.abc import Callable
 import numpy as np
 import pandas as pd
 
+from .dp_calibrated import dp_calibrated_resolver
+from .dp_ladder import dp_ladder_resolver
 from .global_ransac import global_ransac_resolver
 from .nearest import nearest_resolver
 
@@ -34,6 +36,8 @@ Resolver = Callable[..., tuple[pd.DataFrame, int]]
 MATCHERS: dict[str, Resolver] = {
     "nearest": nearest_resolver,
     "global_ransac": global_ransac_resolver,
+    "dp_ladder": dp_ladder_resolver,
+    "dp_calibrated": dp_calibrated_resolver,
 }
 
 

--- a/spectrum_fundamentals/annotation/matchers/__init__.py
+++ b/spectrum_fundamentals/annotation/matchers/__init__.py
@@ -53,9 +53,7 @@ def resolve_matches(
     try:
         resolver = MATCHERS[method]
     except KeyError as exc:
-        raise ValueError(
-            f"Unknown matching_method '{method}'. Available: {sorted(MATCHERS)}"
-        ) from exc
+        raise ValueError(f"Unknown matching_method '{method}'. Available: {sorted(MATCHERS)}") from exc
     return resolver(
         candidates=candidates,
         peaks_masses=peaks_masses,

--- a/spectrum_fundamentals/annotation/matchers/dp_calibrated.py
+++ b/spectrum_fundamentals/annotation/matchers/dp_calibrated.py
@@ -137,7 +137,8 @@ def dp_calibrated_resolver(
     if n_invalid:
         logger.warning(
             "dp_calibrated: dropping %d/%d candidate rows with non-finite or non-positive mass",
-            n_invalid, n_input,
+            n_invalid,
+            n_input,
         )
         df = df.loc[valid].reset_index(drop=True)
     if len(df) == 0:
@@ -159,9 +160,7 @@ def dp_calibrated_resolver(
             df, scale, skip_penalty, ladder_weight, intensity_weight, emit_col="ppm_residual"
         )
     else:
-        chosen_idx = _iterate_dp(
-            df, theo, ppm, line, scale, skip_penalty, ladder_weight, intensity_weight, iterations
-        )
+        chosen_idx = _iterate_dp(df, theo, ppm, line, scale, skip_penalty, ladder_weight, intensity_weight, iterations)
 
     if unique_peak:
         chosen_idx = _greedy_unique_peaks(df, chosen_idx, sort_col="dev_from_line")
@@ -170,7 +169,9 @@ def dp_calibrated_resolver(
     if min_match_fraction > 0 and matched_slots < min_match_fraction * n_slots:
         logger.info(
             "dp_calibrated: matched only %d/%d slots (< %.2f), falling back to nearest",
-            matched_slots, n_slots, min_match_fraction,
+            matched_slots,
+            n_slots,
+            min_match_fraction,
         )
         return _fallback_to_nearest(df, n_input)
 
@@ -224,7 +225,9 @@ def _trustworthy_line(
     if inlier_slots < min_inlier_fraction * n_slots:
         logger.info(
             "dp_calibrated: calibration fit explains only %d/%d slots (< %.2f), using raw ladder DP",
-            inlier_slots, n_slots, min_inlier_fraction,
+            inlier_slots,
+            n_slots,
+            min_inlier_fraction,
         )
         return None
     return a, b

--- a/spectrum_fundamentals/annotation/matchers/dp_calibrated.py
+++ b/spectrum_fundamentals/annotation/matchers/dp_calibrated.py
@@ -1,0 +1,317 @@
+"""Calibrated DP matcher -- RANSAC drift fit + b/y ladder DP combined.
+
+Fuses ``global_ransac`` and ``dp_ladder``: it first robustly fits a global
+mass-calibration line ``ppm_residual ~ a + b * theoretical_mass`` over the
+candidate cloud (RANSAC), then runs the ladder DP but measures each fragment's
+emission penalty as the deviation *from that fitted line* instead of from the
+raw theoretical position. De-drifting the emission removes the tension in plain
+``dp_ladder`` between absolute m/z closeness and ladder consistency, so a
+surviving peak must agree with both the global calibration and the local ladder
+spacing/monotonicity.
+
+The two parent matchers are exactly the two block-coordinate steps of one joint
+objective over (line parameters, peak assignment): fixing the assignment and
+solving the line is a regression (``global_ransac``'s fit); fixing the line and
+solving the assignment is the ladder DP (``dp_ladder``). With ``iterations > 1``
+the resolver alternates them EM/ICP-style -- re-fit the line on the
+DP-selected matches (now de-noised), then re-run the DP.
+
+Robust degradation: if the calibration line can't be trusted (too few
+candidates, a non-converging RANSAC, a non-finite fit, or one that explains too
+few fragment slots) the emission falls back to the raw residual -- i.e. plain
+``dp_ladder``. The ladder DP in turn falls back to ``nearest`` under the
+``min_match_fraction`` floor. Every numeric input is range-checked and
+non-finite rows/values are dropped or neutralised before the maths runs.
+"""
+
+import logging
+import numbers
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LinearRegression, RANSACRegressor
+
+from .dp_ladder import (
+    _REQUIRED_COLUMNS,
+    _SLOT_COLUMNS,
+    _greedy_unique_peaks,
+    _resolve_ppm_scale,
+    _run_dp_assignment,
+)
+from .dp_ladder import _validate_hyperparameters as _validate_dp_hyperparameters
+from .global_ransac import _resolve_residual_threshold
+from .nearest import nearest_resolver
+
+logger = logging.getLogger(__name__)
+
+# Diagnostic columns this resolver adds; stripped before any nearest fallback.
+_DIAGNOSTIC_COLUMNS = ("ppm_residual", "dev_from_line")
+
+
+def dp_calibrated_resolver(
+    candidates: list[dict[str, Any]] | None,
+    peaks_masses: np.ndarray | None = None,
+    peaks_intensity: np.ndarray | None = None,
+    unmod_sequence: str | None = None,
+    *,
+    ppm_scale: float | None = None,
+    skip_penalty: float = 1.0,
+    ladder_weight: float = 2.0,
+    intensity_weight: float = 0.0,
+    unique_peak: bool = True,
+    min_match_fraction: float = 0.0,
+    residual_threshold_ppm: float | None = None,
+    min_samples: int = 2,
+    max_trials: int = 100,
+    random_state: int | None = 42,
+    min_inlier_fraction: float = 0.5,
+    iterations: int = 1,
+    mass_tolerance: float | None = None,
+    unit_mass_tolerance: str | None = None,
+    **kwargs: Any,
+) -> tuple[pd.DataFrame, int]:
+    """Resolve candidates by a RANSAC-calibrated ladder DP.
+
+    :param candidates: rows from ``match_peaks``. May be ``None`` or empty.
+    :param peaks_masses: unused; part of the resolver contract.
+    :param peaks_intensity: unused; part of the resolver contract.
+    :param unmod_sequence: unused; part of the resolver contract.
+    :param ppm_scale: ppm scale ``s`` for the DP emission/transition penalties;
+        see ``dp_ladder``. Derived from the matching tolerance when ``None``.
+    :param skip_penalty: positive flat cost of leaving a fragment unmatched.
+    :param ladder_weight: non-negative weight on the gap-consistency term. Once
+        the emission is drift-corrected it no longer needs to fight global
+        drift, so it can be lowered relative to ``dp_ladder`` if desired.
+    :param intensity_weight: non-negative reward weight on observed (normalised)
+        intensity. ``0`` keeps the cost purely geometric. Never uses Prosit.
+    :param unique_peak: if True (default), enforce one fragment per observed peak
+        across ladders, resolving collisions by ascending deviation-from-line.
+    :param min_match_fraction: in ``[0, 1]``; if the DP matches fewer than this
+        fraction of fragment slots, defer the spectrum to ``nearest``. ``0``
+        (default) disables the floor.
+    :param residual_threshold_ppm: RANSAC inlier band (ppm) for the calibration
+        fit. Derived from the matching tolerance when ``None``.
+    :param min_samples: minimum samples per RANSAC trial; must be ``>= 2``. Also
+        the minimum candidate count below which no line is fitted.
+    :param max_trials: maximum RANSAC iterations; must be ``>= 1``.
+    :param random_state: RANSAC seed; ``None`` for non-deterministic behaviour.
+    :param min_inlier_fraction: in ``[0, 1]``. The calibration line is trusted
+        only if its inliers span at least this fraction of fragment slots;
+        otherwise the emission falls back to the raw residual (plain
+        ``dp_ladder``). ``0`` always trusts a finite fit.
+    :param iterations: number of EM/ICP-style passes (``>= 1``). After the
+        initial RANSAC fit, each extra pass re-fits the line (ordinary least
+        squares) on the current DP-selected matches and re-runs the DP, stopping
+        early once the assignment stabilises.
+    :param mass_tolerance: matching tolerance used to derive ``ppm_scale`` and
+        ``residual_threshold_ppm`` when those are not given. Forwarded by
+        ``_annotate_linear_spectrum``.
+    :param unit_mass_tolerance: unit of ``mass_tolerance`` (``"ppm"`` or ``"da"``).
+    :raises ValueError: if any hyperparameter is out of range, or candidate rows
+        miss a required column.
+    :return: ``(matched_peaks_df, n_dropped)``. The DataFrame carries the
+        contract columns plus ``ppm_residual`` (raw) and ``dev_from_line``
+        (drift-corrected) diagnostics; ``full_name`` is preserved when present.
+    """
+    _validate_dp_hyperparameters(skip_penalty, ladder_weight, intensity_weight, min_match_fraction)
+    _validate_fit_hyperparameters(min_samples, max_trials, min_inlier_fraction, iterations)
+    scale = _resolve_ppm_scale(ppm_scale, mass_tolerance, unit_mass_tolerance)
+    residual_threshold = _resolve_residual_threshold(residual_threshold_ppm, mass_tolerance, unit_mass_tolerance)
+
+    if not candidates:
+        return pd.DataFrame(), 0
+    n_input = len(candidates)
+
+    df = pd.DataFrame(candidates)
+    missing = [c for c in _REQUIRED_COLUMNS if c not in df.columns]
+    if missing:
+        raise ValueError(f"dp_calibrated: candidate rows missing required columns {missing}")
+
+    # Same data hygiene as the sibling resolvers: drop rows that can't yield a
+    # finite ppm residual (non-finite or non-positive mass).
+    exp = df["exp_mass"].to_numpy(dtype=float)
+    theo = df["theoretical_mass"].to_numpy(dtype=float)
+    valid = np.isfinite(exp) & np.isfinite(theo) & (theo > 0)
+    n_invalid = int((~valid).sum())
+    if n_invalid:
+        logger.warning(
+            "dp_calibrated: dropping %d/%d candidate rows with non-finite or non-positive mass",
+            n_invalid, n_input,
+        )
+        df = df.loc[valid].reset_index(drop=True)
+    if len(df) == 0:
+        return pd.DataFrame(columns=df.columns), n_input
+
+    theo = df["theoretical_mass"].to_numpy(dtype=float)
+    ppm = 1e6 * (df["exp_mass"].to_numpy(dtype=float) - theo) / theo
+    df["ppm_residual"] = ppm
+    n_slots = df[_SLOT_COLUMNS].drop_duplicates().shape[0]
+
+    line = _trustworthy_line(
+        df, theo, ppm, residual_threshold, min_samples, max_trials, random_state, min_inlier_fraction, n_slots
+    )
+
+    if line is None:
+        # No trustworthy drift estimate -> plain ladder DP on the raw residual.
+        df["dev_from_line"] = ppm
+        chosen_idx = _run_dp_assignment(
+            df, scale, skip_penalty, ladder_weight, intensity_weight, emit_col="ppm_residual"
+        )
+    else:
+        chosen_idx = _iterate_dp(
+            df, theo, ppm, line, scale, skip_penalty, ladder_weight, intensity_weight, iterations
+        )
+
+    if unique_peak:
+        chosen_idx = _greedy_unique_peaks(df, chosen_idx, sort_col="dev_from_line")
+
+    matched_slots = df.loc[chosen_idx, _SLOT_COLUMNS].drop_duplicates().shape[0]
+    if min_match_fraction > 0 and matched_slots < min_match_fraction * n_slots:
+        logger.info(
+            "dp_calibrated: matched only %d/%d slots (< %.2f), falling back to nearest",
+            matched_slots, n_slots, min_match_fraction,
+        )
+        return _fallback_to_nearest(df, n_input)
+
+    chosen = df.loc[chosen_idx].reset_index(drop=True)
+    return chosen, n_input - len(chosen)
+
+
+def _trustworthy_line(
+    df: pd.DataFrame,
+    theo: np.ndarray,
+    ppm: np.ndarray,
+    residual_threshold: float,
+    min_samples: int,
+    max_trials: int,
+    random_state: int | None,
+    min_inlier_fraction: float,
+    n_slots: int,
+) -> tuple[float, float] | None:
+    """Fit ``ppm ~ a + b*theo`` by RANSAC; return ``(a, b)`` only if trustworthy.
+
+    Returns ``None`` (so the caller uses the raw residual / plain ``dp_ladder``)
+    on any of: too few candidates, a non-converging RANSAC, a non-finite fit, no
+    inliers, or inliers spanning fewer than ``min_inlier_fraction`` of the slots.
+    """
+    if len(df) < min_samples:
+        return None
+    try:
+        ransac = RANSACRegressor(
+            estimator=LinearRegression(),
+            min_samples=min_samples,
+            residual_threshold=residual_threshold,
+            max_trials=max_trials,
+            random_state=random_state,
+        )
+        ransac.fit(theo.reshape(-1, 1), ppm)
+    except ValueError as exc:
+        # InvalidParameterError and "no consensus set found" both subclass
+        # ValueError; either way the fit is untrustworthy.
+        logger.info("dp_calibrated: RANSAC fit did not converge (%s), using raw ladder DP", exc)
+        return None
+
+    a = float(ransac.estimator_.intercept_)
+    b = float(ransac.estimator_.coef_[0])
+    if not (np.isfinite(a) and np.isfinite(b)):
+        return None
+
+    inlier_mask = np.asarray(ransac.inlier_mask_, dtype=bool)
+    if not inlier_mask.any():
+        return None
+    inlier_slots = df.loc[inlier_mask, _SLOT_COLUMNS].drop_duplicates().shape[0]
+    if inlier_slots < min_inlier_fraction * n_slots:
+        logger.info(
+            "dp_calibrated: calibration fit explains only %d/%d slots (< %.2f), using raw ladder DP",
+            inlier_slots, n_slots, min_inlier_fraction,
+        )
+        return None
+    return a, b
+
+
+def _iterate_dp(
+    df: pd.DataFrame,
+    theo: np.ndarray,
+    ppm: np.ndarray,
+    line: tuple[float, float],
+    scale: float,
+    skip_penalty: float,
+    ladder_weight: float,
+    intensity_weight: float,
+    iterations: int,
+) -> list[int]:
+    """Run the de-drifted DP, optionally re-fitting the line on its matches.
+
+    Block-coordinate descent on the joint (line, assignment) objective: each
+    pass writes ``dev_from_line`` for the current line, runs the DP, and -- for
+    all but the last pass -- re-fits the line (OLS) on the DP-selected matches.
+    Stops early when the assignment stops changing. ``df['dev_from_line']`` is
+    left consistent with the returned assignment.
+    """
+    a, b = line
+    chosen_idx: list[int] | None = None
+    for it in range(iterations):
+        df["dev_from_line"] = ppm - (a + b * theo)
+        new_chosen = _run_dp_assignment(
+            df, scale, skip_penalty, ladder_weight, intensity_weight, emit_col="dev_from_line"
+        )
+        if chosen_idx is not None and set(new_chosen) == set(chosen_idx):
+            return new_chosen
+        chosen_idx = new_chosen
+        if it < iterations - 1:
+            refit = _fit_line_ols(
+                df.loc[chosen_idx, "theoretical_mass"].to_numpy(dtype=float),
+                df.loc[chosen_idx, "ppm_residual"].to_numpy(dtype=float),
+            )
+            if refit is None:
+                break
+            a, b = refit
+    return chosen_idx if chosen_idx is not None else []
+
+
+def _fit_line_ols(theo: np.ndarray, ppm: np.ndarray) -> tuple[float, float] | None:
+    """Ordinary least-squares fit of ``ppm ~ a + b*theo``; ``None`` if degenerate.
+
+    Requires at least two distinct theoretical masses (otherwise the slope is
+    undefined) and a finite result.
+    """
+    if theo.size < 2 or np.unique(theo).size < 2:
+        return None
+    try:
+        b, a = np.polyfit(theo, ppm, 1)
+    except (np.linalg.LinAlgError, ValueError):
+        return None
+    if not (np.isfinite(a) and np.isfinite(b)):
+        return None
+    return float(a), float(b)
+
+
+def _fallback_to_nearest(df: pd.DataFrame, n_input: int) -> tuple[pd.DataFrame, int]:
+    """Delegate to ``nearest_resolver`` with diagnostic columns stripped.
+
+    Uses the already-filtered candidate set so the fallback inherits the same
+    data hygiene; ``n_input`` is the original row count so ``n_dropped``
+    reflects "input rows not in output", including non-finite drops.
+    """
+    cleaned = df.drop(columns=list(_DIAGNOSTIC_COLUMNS), errors="ignore")
+    chosen, _ = nearest_resolver(candidates=cleaned.to_dict("records"))
+    chosen = chosen.reset_index(drop=True)
+    return chosen, n_input - len(chosen)
+
+
+def _validate_fit_hyperparameters(
+    min_samples: int, max_trials: int, min_inlier_fraction: float, iterations: int
+) -> None:
+    if not (isinstance(min_samples, numbers.Integral) and min_samples >= 2):
+        raise ValueError(f"min_samples must be an integer >= 2, got {min_samples!r}")
+    if not (isinstance(max_trials, numbers.Integral) and max_trials >= 1):
+        raise ValueError(f"max_trials must be an integer >= 1, got {max_trials!r}")
+    if not (
+        isinstance(min_inlier_fraction, numbers.Real)
+        and np.isfinite(float(min_inlier_fraction))
+        and 0.0 <= min_inlier_fraction <= 1.0
+    ):
+        raise ValueError(f"min_inlier_fraction must be a number in [0, 1], got {min_inlier_fraction!r}")
+    if not (isinstance(iterations, numbers.Integral) and iterations >= 1):
+        raise ValueError(f"iterations must be an integer >= 1, got {iterations!r}")

--- a/spectrum_fundamentals/annotation/matchers/dp_ladder.py
+++ b/spectrum_fundamentals/annotation/matchers/dp_ladder.py
@@ -137,16 +137,17 @@ def dp_ladder_resolver(
     if n_invalid:
         logger.warning(
             "dp_ladder: dropping %d/%d candidate rows with non-finite or non-positive mass",
-            n_invalid, n_input,
+            n_invalid,
+            n_input,
         )
         df = df.loc[valid].reset_index(drop=True)
 
     if len(df) == 0:
         return pd.DataFrame(columns=df.columns), n_input
 
-    df["ppm_residual"] = 1e6 * (df["exp_mass"].to_numpy() - df["theoretical_mass"].to_numpy()) / df[
-        "theoretical_mass"
-    ].to_numpy()
+    df["ppm_residual"] = (
+        1e6 * (df["exp_mass"].to_numpy() - df["theoretical_mass"].to_numpy()) / df["theoretical_mass"].to_numpy()
+    )
 
     n_slots = df[_SLOT_COLUMNS].drop_duplicates().shape[0]
 
@@ -162,7 +163,9 @@ def dp_ladder_resolver(
     if min_match_fraction > 0 and matched_slots < min_match_fraction * n_slots:
         logger.info(
             "dp_ladder: matched only %d/%d slots (< %.2f), falling back to nearest",
-            matched_slots, n_slots, min_match_fraction,
+            matched_slots,
+            n_slots,
+            min_match_fraction,
         )
         return _fallback_to_nearest(df, n_input)
 
@@ -187,9 +190,7 @@ def _run_dp_assignment(
     """
     chosen_idx: list[int] = []
     for _, ladder_df in df.groupby(["ion_type", "charge"], sort=False):
-        chosen_idx.extend(
-            _resolve_ladder(ladder_df, scale, skip_penalty, ladder_weight, intensity_weight, emit_col)
-        )
+        chosen_idx.extend(_resolve_ladder(ladder_df, scale, skip_penalty, ladder_weight, intensity_weight, emit_col))
     return chosen_idx
 
 
@@ -295,9 +296,7 @@ def _relax(states: dict, key: Any, cost: float, prev_key: Any, option: Any) -> N
         states[key] = (cost, prev_key, option)
 
 
-def _greedy_unique_peaks(
-    df: pd.DataFrame, chosen_idx: list[int], sort_col: str = "ppm_residual"
-) -> list[int]:
+def _greedy_unique_peaks(df: pd.DataFrame, chosen_idx: list[int], sort_col: str = "ppm_residual") -> list[int]:
     """Enforce one fragment per observed peak across ladders.
 
     Walks the chosen rows in ascending ``|sort_col|`` and keeps a row only while
@@ -348,11 +347,7 @@ def _resolve_ppm_scale(
     :raises ValueError: if an explicit ``ppm_scale`` is not a positive finite number.
     """
     if ppm_scale is not None:
-        if not (
-            isinstance(ppm_scale, numbers.Real)
-            and np.isfinite(float(ppm_scale))
-            and ppm_scale > 0
-        ):
+        if not (isinstance(ppm_scale, numbers.Real) and np.isfinite(float(ppm_scale)) and ppm_scale > 0):
             raise ValueError(f"ppm_scale must be a positive finite number, got {ppm_scale!r}")
         return float(ppm_scale)
 
@@ -374,31 +369,17 @@ def _validate_hyperparameters(
     intensity_weight: float,
     min_match_fraction: float,
 ) -> None:
-    if not (
-        isinstance(skip_penalty, numbers.Real)
-        and np.isfinite(float(skip_penalty))
-        and skip_penalty > 0
-    ):
+    if not (isinstance(skip_penalty, numbers.Real) and np.isfinite(float(skip_penalty)) and skip_penalty > 0):
         raise ValueError(f"skip_penalty must be a positive finite number, got {skip_penalty!r}")
-    if not (
-        isinstance(ladder_weight, numbers.Real)
-        and np.isfinite(float(ladder_weight))
-        and ladder_weight >= 0
-    ):
+    if not (isinstance(ladder_weight, numbers.Real) and np.isfinite(float(ladder_weight)) and ladder_weight >= 0):
         raise ValueError(f"ladder_weight must be a non-negative finite number, got {ladder_weight!r}")
     if not (
-        isinstance(intensity_weight, numbers.Real)
-        and np.isfinite(float(intensity_weight))
-        and intensity_weight >= 0
+        isinstance(intensity_weight, numbers.Real) and np.isfinite(float(intensity_weight)) and intensity_weight >= 0
     ):
-        raise ValueError(
-            f"intensity_weight must be a non-negative finite number, got {intensity_weight!r}"
-        )
+        raise ValueError(f"intensity_weight must be a non-negative finite number, got {intensity_weight!r}")
     if not (
         isinstance(min_match_fraction, numbers.Real)
         and np.isfinite(float(min_match_fraction))
         and 0.0 <= min_match_fraction <= 1.0
     ):
-        raise ValueError(
-            f"min_match_fraction must be a number in [0, 1], got {min_match_fraction!r}"
-        )
+        raise ValueError(f"min_match_fraction must be a number in [0, 1], got {min_match_fraction!r}")

--- a/spectrum_fundamentals/annotation/matchers/dp_ladder.py
+++ b/spectrum_fundamentals/annotation/matchers/dp_ladder.py
@@ -1,0 +1,404 @@
+"""Dynamic-programming matcher over the b/y ion ladder.
+
+Aligns the candidate cloud from ``match_peaks`` onto the known theoretical
+fragment ladder of the candidate peptide. Processing one ion series at a fixed
+charge (e.g. singly-charged b ions) in increasing theoretical m/z, a
+shortest-path DP picks, per fragment slot, the observed peak that minimises an
+additive cost: an **emission** term ``(ppm / s)^2 - w_I * intensity`` (m/z
+error from theoretical, drift-sensitive), a **transition** term
+``w_L * (gap_ppm / s)^2`` penalising mismatch between the observed and
+theoretical gaps to the previous assigned peak (drift-robust, since a constant
+calibration offset cancels in the gap), and a flat **skip** penalty for
+leaving a slot unmatched. A hard monotonicity constraint keeps assigned m/z
+increasing along the ladder. Backtracking recovers the assignment.
+
+Unlike ``nearest`` (per-slot, closest m/z) and ``global_ransac`` (one global
+calibration line), this uses the sequential ladder structure, so it can reject
+in-window noise that breaks the gap pattern and bridge missing fragments. It
+optimises a geometric cost only -- it never sees Prosit's predicted
+intensities (it runs before the spectral angle is computed), which keeps it
+self-contained.
+
+Like ``global_ransac`` it degrades gracefully to ``nearest``: short ladders
+are matched candidate-by-candidate by the same DP, and an optional
+``min_match_fraction`` floor defers the spectrum when the DP would drop too
+many slots.
+"""
+
+import logging
+import numbers
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .nearest import nearest_resolver
+
+logger = logging.getLogger(__name__)
+
+# Columns every candidate row must carry (shared with the other resolvers).
+_REQUIRED_COLUMNS = ("ion_type", "no", "charge", "exp_mass", "theoretical_mass", "intensity")
+# A fragment slot is identified by this triple; a ladder by (ion_type, charge).
+_SLOT_COLUMNS = ["ion_type", "no", "charge"]
+
+# ppm scale used when it cannot be derived from a ppm matching tolerance
+# (tolerance unset or given in Da). ~Orbitrap MS2 full window.
+_DEFAULT_PPM_SCALE = 20.0
+# Infinitesimal reward per assignment so that, on an exact cost tie, matching a
+# peak beats skipping it -- makes clean spectra reproduce ``nearest`` exactly.
+_MATCH_REWARD_EPS = 1e-9
+# Emission residual (ppm) substituted for a non-finite one so the candidate's
+# cost is huge-but-finite -- it gets skipped instead of poisoning the DP.
+_NONFINITE_EMIT_PPM = 1e6
+
+# Sentinels for the DP. ``_START`` is the "no real peak assigned yet" anchor;
+# ``_SKIP`` marks a slot left unmatched.
+_START = object()
+_SKIP = object()
+
+
+def dp_ladder_resolver(
+    candidates: list[dict[str, Any]] | None,
+    peaks_masses: np.ndarray | None = None,
+    peaks_intensity: np.ndarray | None = None,
+    unmod_sequence: str | None = None,
+    *,
+    ppm_scale: float | None = None,
+    skip_penalty: float = 1.0,
+    ladder_weight: float = 2.0,
+    intensity_weight: float = 0.0,
+    unique_peak: bool = True,
+    min_match_fraction: float = 0.0,
+    mass_tolerance: float | None = None,
+    unit_mass_tolerance: str | None = None,
+    **kwargs: Any,
+) -> tuple[pd.DataFrame, int]:
+    """Resolve candidates by DP alignment to the b/y ion ladder.
+
+    :param candidates: rows from ``match_peaks``. May be ``None`` or empty.
+    :param peaks_masses: unused; part of the resolver contract.
+    :param peaks_intensity: unused; part of the resolver contract.
+    :param unmod_sequence: unused; part of the resolver contract.
+    :param ppm_scale: positive ppm scale ``s`` shared by the emission and
+        transition penalties. If ``None`` (default) it is derived from the
+        matching tolerance: ``mass_tolerance`` when that is in ppm, else
+        ``_DEFAULT_PPM_SCALE``. A peak ``s`` ppm off theoretical contributes
+        unit emission cost.
+    :param skip_penalty: positive flat cost ``lambda`` of leaving a fragment
+        unmatched. With the default scale, an in-window peak (<= tolerance ppm
+        off) that is also ladder-consistent always beats skipping, so clean
+        spectra are matched in full; only ladder-inconsistent in-window peaks
+        are dropped as noise.
+    :param ladder_weight: non-negative weight ``w_L`` on the gap-consistency
+        (transition) term. ``0`` reduces the DP to independent per-slot ppm
+        picking; larger values trust the ladder structure more and are more
+        robust to global mass drift.
+    :param intensity_weight: non-negative weight ``w_I`` rewarding more intense
+        (already-normalised, *observed*) peaks. ``0`` (default) keeps the cost
+        purely geometric. Never uses Prosit predictions.
+    :param unique_peak: if True (default), after the per-ladder DP enforce that
+        each observed peak is claimed by at most one fragment across all
+        ladders, resolving cross-series collisions greedily by ascending ppm
+        error. Monotonicity already guarantees uniqueness *within* a ladder.
+        If False, a peak may back two slots in different series.
+    :param min_match_fraction: in ``[0, 1]``. If the DP matches fewer than this
+        fraction of the candidate fragment slots, defer the whole spectrum to
+        ``nearest`` instead of returning a sparse match set. ``0`` (default)
+        disables the floor -- the skip penalty is the primary control.
+    :param mass_tolerance: matching tolerance used to derive ``ppm_scale`` when
+        it is not given explicitly. Forwarded by ``_annotate_linear_spectrum``.
+    :param unit_mass_tolerance: unit of ``mass_tolerance`` (``"ppm"`` or ``"da"``).
+    :raises ValueError: if any hyperparameter is out of range, or candidate
+        rows miss a required column.
+    :return: ``(matched_peaks_df, n_dropped)``. ``n_dropped`` counts input rows
+        not surviving into the output (skipped slots, losing candidates, greedy
+        uniqueness, or non-finite rows). The DataFrame carries the contract
+        columns plus a ``ppm_residual`` diagnostic; ``full_name`` is preserved
+        when present.
+    """
+    _validate_hyperparameters(skip_penalty, ladder_weight, intensity_weight, min_match_fraction)
+    scale = _resolve_ppm_scale(ppm_scale, mass_tolerance, unit_mass_tolerance)
+
+    if not candidates:
+        return pd.DataFrame(), 0
+    n_input = len(candidates)
+
+    df = pd.DataFrame(candidates)
+    missing = [c for c in _REQUIRED_COLUMNS if c not in df.columns]
+    if missing:
+        raise ValueError(f"dp_ladder: candidate rows missing required columns {missing}")
+
+    # Drop rows that can't yield a finite ppm residual (mirrors global_ransac's
+    # data hygiene): non-finite masses or a non-positive theoretical mass.
+    exp = df["exp_mass"].to_numpy(dtype=float)
+    theo = df["theoretical_mass"].to_numpy(dtype=float)
+    valid = np.isfinite(exp) & np.isfinite(theo) & (theo > 0)
+    n_invalid = int((~valid).sum())
+    if n_invalid:
+        logger.warning(
+            "dp_ladder: dropping %d/%d candidate rows with non-finite or non-positive mass",
+            n_invalid, n_input,
+        )
+        df = df.loc[valid].reset_index(drop=True)
+
+    if len(df) == 0:
+        return pd.DataFrame(columns=df.columns), n_input
+
+    df["ppm_residual"] = 1e6 * (df["exp_mass"].to_numpy() - df["theoretical_mass"].to_numpy()) / df[
+        "theoretical_mass"
+    ].to_numpy()
+
+    n_slots = df[_SLOT_COLUMNS].drop_duplicates().shape[0]
+
+    # Run the DP independently on each ladder (one ion series at one charge).
+    chosen_idx = _run_dp_assignment(df, scale, skip_penalty, ladder_weight, intensity_weight)
+
+    if unique_peak:
+        chosen_idx = _greedy_unique_peaks(df, chosen_idx)
+
+    # Safety floor: a DP that explains too few slots is more likely mis-tuned
+    # than informative; fall back to nearest rather than return a sparse set.
+    matched_slots = df.loc[chosen_idx, _SLOT_COLUMNS].drop_duplicates().shape[0]
+    if min_match_fraction > 0 and matched_slots < min_match_fraction * n_slots:
+        logger.info(
+            "dp_ladder: matched only %d/%d slots (< %.2f), falling back to nearest",
+            matched_slots, n_slots, min_match_fraction,
+        )
+        return _fallback_to_nearest(df, n_input)
+
+    chosen = df.loc[chosen_idx].reset_index(drop=True)
+    return chosen, n_input - len(chosen)
+
+
+def _run_dp_assignment(
+    df: pd.DataFrame,
+    scale: float,
+    skip_penalty: float,
+    ladder_weight: float,
+    intensity_weight: float,
+    emit_col: str = "ppm_residual",
+) -> list[int]:
+    """Run the per-ladder DP across every ``(ion_type, charge)`` series in ``df``.
+
+    ``emit_col`` selects the ppm column used for the emission penalty: the raw
+    ``"ppm_residual"`` for the plain ladder DP, or a drift-corrected
+    deviation-from-line column for the calibrated variant (``dp_calibrated``).
+    Returns the chosen df indices (at most one observed peak per fragment slot).
+    """
+    chosen_idx: list[int] = []
+    for _, ladder_df in df.groupby(["ion_type", "charge"], sort=False):
+        chosen_idx.extend(
+            _resolve_ladder(ladder_df, scale, skip_penalty, ladder_weight, intensity_weight, emit_col)
+        )
+    return chosen_idx
+
+
+def _resolve_ladder(
+    ladder_df: pd.DataFrame,
+    scale: float,
+    skip_penalty: float,
+    ladder_weight: float,
+    intensity_weight: float,
+    emit_col: str = "ppm_residual",
+) -> list[int]:
+    """Run the alignment DP over one ion series, returning chosen df indices.
+
+    ``ladder_df`` holds every candidate row for a single ``(ion_type, charge)``
+    pair; it may contain several candidate peaks per fragment slot. Slots are
+    ordered by theoretical m/z (equivalently fragment number). ``emit_col`` is
+    the column whose value drives the per-peak emission penalty (see
+    :func:`_run_dp_assignment`).
+    """
+    # Build ordered slots, each carrying its candidate peaks.
+    slots: list[dict[str, Any]] = []
+    for theo, slot_df in sorted(ladder_df.groupby("theoretical_mass", sort=False), key=lambda kv: kv[0]):
+        cands = []
+        for idx, row in slot_df.iterrows():
+            # A non-finite intensity would poison the additive cost (note that
+            # ``0.0 * nan == nan``, so even intensity_weight=0 is not safe);
+            # treat it as zero reward. The untouched value still reaches output.
+            intensity = float(row["intensity"])
+            if not np.isfinite(intensity):
+                intensity = 0.0
+            # The emission residual is finite for both callers (filtered inputs);
+            # guard defensively so a stray non-finite value forces a skip rather
+            # than poisoning every cost it touches.
+            eppm = float(row[emit_col])
+            if not np.isfinite(eppm):
+                eppm = _NONFINITE_EMIT_PPM
+            cands.append(
+                {
+                    "idx": int(idx),
+                    "mz": float(row["exp_mass"]),
+                    "intensity": intensity,
+                    "eppm": eppm,
+                }
+            )
+        slots.append({"theo": float(theo), "cands": cands})
+
+    n = len(slots)
+    if n == 0:
+        return []
+
+    # Forward DP. ``prev_states`` maps an anchor key -> (cost, prev_key, option)
+    # where the anchor is the last *real* peak assigned so far. ``layers[k]`` is
+    # the state table after processing slot k, used for backtracking.
+    layers: list[dict] = []
+    prev_states: dict = {_START: (0.0, None, None)}
+
+    for k in range(n):
+        theo_k = slots[k]["theo"]
+        new_states: dict = {}
+        for akey, (acost, _, _) in prev_states.items():
+            # Option 1: skip slot k -- anchor (last real peak) is unchanged.
+            _relax(new_states, akey, acost + skip_penalty, akey, _SKIP)
+
+            # Option 2: assign one of slot k's candidate peaks.
+            if akey is _START:
+                a_mz = None
+                a_theo = None
+            else:
+                aj, ali = akey
+                a_mz = slots[aj]["cands"][ali]["mz"]
+                a_theo = slots[aj]["theo"]
+            for li, c in enumerate(slots[k]["cands"]):
+                if a_mz is not None:
+                    d_obs = c["mz"] - a_mz
+                    if d_obs <= 0:  # hard monotonicity: peaks must increase in m/z
+                        continue
+                    d_theo = theo_k - a_theo
+                    gap_ppm = 1e6 * (d_obs - d_theo) / theo_k
+                    trans = ladder_weight * (gap_ppm / scale) ** 2
+                else:
+                    trans = 0.0  # first real peak in the ladder: emission only
+                emit = (c["eppm"] / scale) ** 2 - intensity_weight * c["intensity"] - _MATCH_REWARD_EPS
+                _relax(new_states, (k, li), acost + emit + trans, akey, li)
+        layers.append(new_states)
+        prev_states = new_states
+
+    # Pick the lowest-cost end state and backtrack the per-slot decisions.
+    best_key = min(prev_states, key=lambda key: prev_states[key][0])
+    chosen: list[int] = []
+    key = best_key
+    for k in range(n - 1, -1, -1):
+        _, prev_key, option = layers[k][key]
+        if option is not _SKIP and option is not None:
+            chosen.append(slots[k]["cands"][option]["idx"])
+        key = prev_key
+    return chosen
+
+
+def _relax(states: dict, key: Any, cost: float, prev_key: Any, option: Any) -> None:
+    """Keep the minimum-cost route to ``key`` (stable on exact ties)."""
+    current = states.get(key)
+    if current is None or cost < current[0]:
+        states[key] = (cost, prev_key, option)
+
+
+def _greedy_unique_peaks(
+    df: pd.DataFrame, chosen_idx: list[int], sort_col: str = "ppm_residual"
+) -> list[int]:
+    """Enforce one fragment per observed peak across ladders.
+
+    Walks the chosen rows in ascending ``|sort_col|`` and keeps a row only while
+    its ``exp_mass`` is still unclaimed. Resolves cross-series collisions (the
+    same peak picked by, say, a b ladder and a y ladder); within a ladder the
+    DP's monotonicity already guarantees distinct peaks. ``sort_col`` is the
+    quantity the DP minimised (raw ppm for ``dp_ladder``, deviation-from-line
+    for ``dp_calibrated``), so the better-fitting fragment wins the shared peak.
+    """
+    if not chosen_idx:
+        return chosen_idx
+    order = df.loc[chosen_idx, sort_col].abs().sort_values(kind="stable").index
+    used_peaks: set[float] = set()
+    kept: list[int] = []
+    for idx in order:
+        peak = float(df.at[idx, "exp_mass"])
+        if peak in used_peaks:
+            continue
+        used_peaks.add(peak)
+        kept.append(int(idx))
+    return kept
+
+
+def _fallback_to_nearest(df: pd.DataFrame, n_input: int) -> tuple[pd.DataFrame, int]:
+    """Delegate to ``nearest_resolver`` with the diagnostic column stripped.
+
+    Uses the already-filtered candidate set so the fallback inherits the same
+    data hygiene; ``n_input`` is the original row count so ``n_dropped``
+    reflects "input rows not in output", including non-finite drops.
+    """
+    cleaned = df.drop(columns=["ppm_residual"], errors="ignore")
+    chosen, _ = nearest_resolver(candidates=cleaned.to_dict("records"))
+    chosen = chosen.reset_index(drop=True)
+    return chosen, n_input - len(chosen)
+
+
+def _resolve_ppm_scale(
+    ppm_scale: float | None,
+    mass_tolerance: float | None,
+    unit_mass_tolerance: str | None,
+) -> float:
+    """Resolve the ppm scale ``s`` for the emission/transition penalties.
+
+    An explicit ``ppm_scale`` always wins (and is validated). Otherwise derive
+    it from the matching tolerance: the tolerance itself when given in ppm
+    (so an in-window peak has emission <= 1), else a fixed fallback.
+
+    :raises ValueError: if an explicit ``ppm_scale`` is not a positive finite number.
+    """
+    if ppm_scale is not None:
+        if not (
+            isinstance(ppm_scale, numbers.Real)
+            and np.isfinite(float(ppm_scale))
+            and ppm_scale > 0
+        ):
+            raise ValueError(f"ppm_scale must be a positive finite number, got {ppm_scale!r}")
+        return float(ppm_scale)
+
+    if (
+        unit_mass_tolerance is not None
+        and str(unit_mass_tolerance).lower() == "ppm"
+        and isinstance(mass_tolerance, numbers.Real)
+        and np.isfinite(float(mass_tolerance))
+        and mass_tolerance > 0
+    ):
+        return float(mass_tolerance)
+
+    return _DEFAULT_PPM_SCALE
+
+
+def _validate_hyperparameters(
+    skip_penalty: float,
+    ladder_weight: float,
+    intensity_weight: float,
+    min_match_fraction: float,
+) -> None:
+    if not (
+        isinstance(skip_penalty, numbers.Real)
+        and np.isfinite(float(skip_penalty))
+        and skip_penalty > 0
+    ):
+        raise ValueError(f"skip_penalty must be a positive finite number, got {skip_penalty!r}")
+    if not (
+        isinstance(ladder_weight, numbers.Real)
+        and np.isfinite(float(ladder_weight))
+        and ladder_weight >= 0
+    ):
+        raise ValueError(f"ladder_weight must be a non-negative finite number, got {ladder_weight!r}")
+    if not (
+        isinstance(intensity_weight, numbers.Real)
+        and np.isfinite(float(intensity_weight))
+        and intensity_weight >= 0
+    ):
+        raise ValueError(
+            f"intensity_weight must be a non-negative finite number, got {intensity_weight!r}"
+        )
+    if not (
+        isinstance(min_match_fraction, numbers.Real)
+        and np.isfinite(float(min_match_fraction))
+        and 0.0 <= min_match_fraction <= 1.0
+    ):
+        raise ValueError(
+            f"min_match_fraction must be a number in [0, 1], got {min_match_fraction!r}"
+        )

--- a/spectrum_fundamentals/annotation/matchers/global_ransac.py
+++ b/spectrum_fundamentals/annotation/matchers/global_ransac.py
@@ -1,0 +1,292 @@
+"""Per-spectrum mass-calibration matcher.
+
+Fits a RANSAC line ``ppm_residual ~ a + b * theoretical_mass`` over the
+candidate cloud returned by ``match_peaks``, then for each fragment slot picks
+the inlier closest to the fitted line. Optionally enforces one-peak-per-slot
+uniqueness via greedy assignment on ascending deviation from the fit.
+
+Designed to correct systematic mass-calibration drift within a single MS2
+spectrum and to reject noise spikes that happen to fall inside the ppm window
+but don't lie on the global drift line.
+
+The matcher degrades gracefully to ``nearest`` whenever the fit can't be
+trusted: too few candidates, a non-converging RANSAC, no inliers, or a
+converged fit that still retains fewer than ``min_inlier_fraction`` of the
+fragment slots (a "bad" fit that would otherwise silently decimate matches).
+"""
+
+import logging
+import numbers
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LinearRegression, RANSACRegressor
+
+from .nearest import nearest_resolver
+
+logger = logging.getLogger(__name__)
+
+# Columns every candidate row must carry. ``match_peaks`` always emits these
+# for the linear b/y path; multifrag additionally carries ``full_name``,
+# which we propagate transparently when present.
+_REQUIRED_COLUMNS = ("ion_type", "no", "charge", "exp_mass", "theoretical_mass", "intensity")
+_DIAGNOSTIC_COLUMNS = ("ppm_residual", "abs_dev_from_fit")
+_SLOT_COLUMNS = ["ion_type", "no", "charge"]
+
+# Used when the residual threshold cannot be derived from the matching
+# tolerance (tolerance unset or given in Da). Reasonable for FTMS data.
+_DEFAULT_RESIDUAL_THRESHOLD_PPM = 5.0
+# Fraction of the (ppm) matching tolerance to use as the inlier band when the
+# threshold is derived rather than given explicitly.
+_TOLERANCE_THRESHOLD_FRACTION = 0.5
+
+
+def global_ransac_resolver(
+    candidates: list[dict[str, Any]] | None,
+    peaks_masses: np.ndarray | None = None,
+    peaks_intensity: np.ndarray | None = None,
+    unmod_sequence: str | None = None,
+    *,
+    residual_threshold_ppm: float | None = None,
+    min_samples: int = 2,
+    max_trials: int = 100,
+    random_state: int | None = 42,
+    unique_peak: bool = True,
+    min_inlier_fraction: float = 0.5,
+    mass_tolerance: float | None = None,
+    unit_mass_tolerance: str | None = None,
+    **kwargs: Any,
+) -> tuple[pd.DataFrame, int]:
+    """Resolve candidates via RANSAC mass-calibration fit, then per-slot pick.
+
+    :param candidates: rows from ``match_peaks``. May be ``None`` or empty.
+    :param peaks_masses: unused; part of the resolver contract.
+    :param peaks_intensity: unused; part of the resolver contract.
+    :param unmod_sequence: unused; part of the resolver contract.
+    :param residual_threshold_ppm: positive ppm tolerance for inlier classification.
+        If ``None`` (default), it is derived from the matching tolerance:
+        ``_TOLERANCE_THRESHOLD_FRACTION * mass_tolerance`` when the tolerance is in
+        ppm, otherwise ``_DEFAULT_RESIDUAL_THRESHOLD_PPM``. Pass an explicit value to
+        override.
+    :param min_samples: minimum samples per RANSAC trial; must be ``>= 2``.
+    :param max_trials: maximum RANSAC iterations; must be ``>= 1``.
+    :param random_state: RANSAC seed; pass ``None`` for non-deterministic behaviour.
+    :param unique_peak: if True (default), enforce one observed peak per fragment
+        slot AND one fragment slot per observed peak via greedy assignment in
+        ascending deviation from the fit. If False, peaks may be reused across
+        slots (preserves the legacy linear-path behaviour).
+    :param min_inlier_fraction: in ``[0, 1]``. If the converged fit keeps inliers
+        spanning fewer than this fraction of the candidate fragment slots, defer to
+        ``nearest`` instead of returning a decimated match set. ``0`` disables the
+        check. Default ``0.5``.
+    :param mass_tolerance: matching tolerance used to derive ``residual_threshold_ppm``
+        when it is not given explicitly. Forwarded by ``_annotate_linear_spectrum``.
+    :param unit_mass_tolerance: unit of ``mass_tolerance`` (``"ppm"`` or ``"da"``).
+    :raises ValueError: if any hyperparameter is out of range, or candidate rows
+        miss any required column.
+    :return: ``(matched_peaks_df, n_dropped)``. ``n_dropped`` is the count of
+        input rows that did not survive into the output (rejected as outliers,
+        lost to greedy uniqueness, or dropped as non-finite). The DataFrame
+        carries the contract columns plus ``ppm_residual`` and
+        ``abs_dev_from_fit`` for downstream diagnostics; the multifrag
+        ``full_name`` column is preserved when present.
+    """
+    _validate_hyperparameters(min_samples, max_trials, min_inlier_fraction)
+    residual_threshold = _resolve_residual_threshold(
+        residual_threshold_ppm, mass_tolerance, unit_mass_tolerance
+    )
+
+    if not candidates:
+        return pd.DataFrame(), 0
+    n_input = len(candidates)
+
+    df = pd.DataFrame(candidates)
+    missing = [c for c in _REQUIRED_COLUMNS if c not in df.columns]
+    if missing:
+        raise ValueError(
+            f"global_ransac: candidate rows missing required columns {missing}"
+        )
+
+    # Drop rows that can't yield a finite ppm residual. sklearn's RANSAC raises
+    # on NaN/inf in y, and a non-positive theoretical_mass would divide-by-zero
+    # or flip the sign of the ppm scale. Real fragment m/z is always positive
+    # and finite; this guard catches corrupt or partially-populated inputs
+    # without taking the whole annotate_spectra loop down.
+    exp = df["exp_mass"].to_numpy()
+    theo = df["theoretical_mass"].to_numpy()
+    valid = np.isfinite(exp) & np.isfinite(theo) & (theo > 0)
+    n_invalid = int((~valid).sum())
+    if n_invalid:
+        logger.warning(
+            "global_ransac: dropping %d/%d candidate rows with non-finite or non-positive mass",
+            n_invalid, n_input,
+        )
+        df = df.loc[valid].reset_index(drop=True)
+
+    if len(df) == 0:
+        return pd.DataFrame(columns=df.columns), n_input
+
+    df["ppm_residual"] = 1e6 * (df["exp_mass"].to_numpy() - df["theoretical_mass"].to_numpy()) / df["theoretical_mass"].to_numpy()
+
+    if len(df) < min_samples:
+        logger.info(
+            "global_ransac: %d valid candidates < min_samples=%d, falling back to nearest",
+            len(df), min_samples,
+        )
+        return _fallback_to_nearest(df, n_input)
+
+    n_slots = df[_SLOT_COLUMNS].drop_duplicates().shape[0]
+
+    X = df[["theoretical_mass"]].to_numpy()
+    y = df["ppm_residual"].to_numpy()
+
+    ransac = RANSACRegressor(
+        estimator=LinearRegression(),
+        min_samples=min_samples,
+        residual_threshold=residual_threshold,
+        max_trials=max_trials,
+        random_state=random_state,
+    )
+    try:
+        ransac.fit(X, y)
+    except ValueError as exc:
+        # Covers InvalidParameterError (subclass of ValueError) and "no consensus
+        # set found" — both mean the fit can't be trusted; defer to nearest so
+        # the spectrum still gets matched rather than producing a zero vector.
+        logger.info(
+            "global_ransac: RANSAC fit did not converge (%s), falling back to nearest",
+            exc,
+        )
+        return _fallback_to_nearest(df, n_input)
+
+    predicted = ransac.predict(X)
+    df["abs_dev_from_fit"] = np.abs(y - predicted)
+    inlier_mask = np.asarray(ransac.inlier_mask_, dtype=bool)
+    if not inlier_mask.any():
+        logger.info("global_ransac: no inliers after fit, falling back to nearest")
+        return _fallback_to_nearest(df, n_input)
+
+    inliers = df.loc[inlier_mask]
+
+    # Guard against a converged-but-bad fit. RANSAC always reports at least
+    # ``min_samples`` inliers, so "it converged" does not mean "it explained the
+    # spectrum". If the inliers cover too few of the fragment slots, the fitted
+    # line is more likely noise than calibration drift; deferring to nearest is
+    # safer than silently dropping most matches.
+    inlier_slots = inliers[_SLOT_COLUMNS].drop_duplicates().shape[0]
+    if inlier_slots < min_inlier_fraction * n_slots:
+        logger.info(
+            "global_ransac: fit kept inliers for only %d/%d slots (< %.2f), falling back to nearest",
+            inlier_slots, n_slots, min_inlier_fraction,
+        )
+        return _fallback_to_nearest(df, n_input)
+
+    inliers = inliers.sort_values("abs_dev_from_fit", ascending=True, kind="stable")
+
+    if unique_peak:
+        chosen = _greedy_unique_assignment(inliers)
+    else:
+        chosen = inliers.drop_duplicates(subset=_SLOT_COLUMNS, keep="first")
+
+    chosen = chosen.reset_index(drop=True)
+    return chosen, n_input - len(chosen)
+
+
+def _greedy_unique_assignment(inliers: pd.DataFrame) -> pd.DataFrame:
+    """Walk inliers (already sorted by ascending abs_dev_from_fit) and keep a row
+    iff its ``(ion_type, no, charge)`` slot AND its ``exp_mass`` peak are both
+    still unclaimed. Deterministic given a stable input order.
+    """
+    ion_types = inliers["ion_type"].to_numpy()
+    nos = inliers["no"].to_numpy()
+    charges = inliers["charge"].to_numpy()
+    masses = inliers["exp_mass"].to_numpy()
+
+    used_slots: set[tuple] = set()
+    used_peaks: set = set()
+    keep = np.zeros(len(inliers), dtype=bool)
+    for i in range(len(inliers)):
+        slot = (ion_types[i], nos[i], charges[i])
+        peak = masses[i]
+        if slot in used_slots or peak in used_peaks:
+            continue
+        keep[i] = True
+        used_slots.add(slot)
+        used_peaks.add(peak)
+    return inliers[keep]
+
+
+def _fallback_to_nearest(df: pd.DataFrame, n_input: int) -> tuple[pd.DataFrame, int]:
+    """Delegate to ``nearest_resolver`` with diagnostic columns stripped.
+
+    Uses the *already-filtered* candidate set (i.e. non-finite rows have been
+    removed) so the fallback path inherits the same data hygiene as the RANSAC
+    path. ``n_input`` is the count of rows the user originally passed in; we
+    use it so ``n_dropped`` correctly reflects "input rows not in output",
+    including those filtered as non-finite.
+    """
+    cleaned = df.drop(columns=list(_DIAGNOSTIC_COLUMNS), errors="ignore")
+    chosen, _ = nearest_resolver(candidates=cleaned.to_dict("records"))
+    chosen = chosen.reset_index(drop=True)
+    return chosen, n_input - len(chosen)
+
+
+def _resolve_residual_threshold(
+    residual_threshold_ppm: float | None,
+    mass_tolerance: float | None,
+    unit_mass_tolerance: str | None,
+) -> float:
+    """Resolve the RANSAC inlier band (ppm).
+
+    An explicit ``residual_threshold_ppm`` always wins (and is validated). When
+    omitted, derive it from the matching tolerance so the band scales with the
+    instrument: a fraction of the window for ppm tolerances, else a fixed
+    fallback.
+
+    :raises ValueError: if an explicit ``residual_threshold_ppm`` is not a positive
+        finite number.
+    """
+    if residual_threshold_ppm is not None:
+        if not (
+            isinstance(residual_threshold_ppm, numbers.Real)
+            and np.isfinite(float(residual_threshold_ppm))
+            and residual_threshold_ppm > 0
+        ):
+            raise ValueError(
+                f"residual_threshold_ppm must be a positive finite number, "
+                f"got {residual_threshold_ppm!r}"
+            )
+        return float(residual_threshold_ppm)
+
+    if (
+        unit_mass_tolerance is not None
+        and str(unit_mass_tolerance).lower() == "ppm"
+        and isinstance(mass_tolerance, numbers.Real)
+        and np.isfinite(float(mass_tolerance))
+        and mass_tolerance > 0
+    ):
+        return _TOLERANCE_THRESHOLD_FRACTION * float(mass_tolerance)
+
+    return _DEFAULT_RESIDUAL_THRESHOLD_PPM
+
+
+def _validate_hyperparameters(
+    min_samples: int, max_trials: int, min_inlier_fraction: float
+) -> None:
+    if not (isinstance(min_samples, numbers.Integral) and min_samples >= 2):
+        raise ValueError(
+            f"min_samples must be an integer >= 2, got {min_samples!r}"
+        )
+    if not (isinstance(max_trials, numbers.Integral) and max_trials >= 1):
+        raise ValueError(
+            f"max_trials must be an integer >= 1, got {max_trials!r}"
+        )
+    if not (
+        isinstance(min_inlier_fraction, numbers.Real)
+        and np.isfinite(float(min_inlier_fraction))
+        and 0.0 <= min_inlier_fraction <= 1.0
+    ):
+        raise ValueError(
+            f"min_inlier_fraction must be a number in [0, 1], got {min_inlier_fraction!r}"
+        )

--- a/spectrum_fundamentals/annotation/matchers/global_ransac.py
+++ b/spectrum_fundamentals/annotation/matchers/global_ransac.py
@@ -93,9 +93,7 @@ def global_ransac_resolver(
         ``full_name`` column is preserved when present.
     """
     _validate_hyperparameters(min_samples, max_trials, min_inlier_fraction)
-    residual_threshold = _resolve_residual_threshold(
-        residual_threshold_ppm, mass_tolerance, unit_mass_tolerance
-    )
+    residual_threshold = _resolve_residual_threshold(residual_threshold_ppm, mass_tolerance, unit_mass_tolerance)
 
     if not candidates:
         return pd.DataFrame(), 0
@@ -104,9 +102,7 @@ def global_ransac_resolver(
     df = pd.DataFrame(candidates)
     missing = [c for c in _REQUIRED_COLUMNS if c not in df.columns]
     if missing:
-        raise ValueError(
-            f"global_ransac: candidate rows missing required columns {missing}"
-        )
+        raise ValueError(f"global_ransac: candidate rows missing required columns {missing}")
 
     # Drop rows that can't yield a finite ppm residual. sklearn's RANSAC raises
     # on NaN/inf in y, and a non-positive theoretical_mass would divide-by-zero
@@ -120,7 +116,8 @@ def global_ransac_resolver(
     if n_invalid:
         logger.warning(
             "global_ransac: dropping %d/%d candidate rows with non-finite or non-positive mass",
-            n_invalid, n_input,
+            n_invalid,
+            n_input,
         )
         df = df.loc[valid].reset_index(drop=True)
 
@@ -133,7 +130,8 @@ def global_ransac_resolver(
     if len(df) < min_samples:
         logger.info(
             "global_ransac: %d valid candidates < min_samples=%d, falling back to nearest",
-            len(df), min_samples,
+            len(df),
+            min_samples,
         )
         return _fallback_to_nearest(df, n_input)
 
@@ -179,7 +177,9 @@ def global_ransac_resolver(
     if inlier_slots < min_inlier_fraction * n_slots:
         logger.info(
             "global_ransac: fit kept inliers for only %d/%d slots (< %.2f), falling back to nearest",
-            inlier_slots, n_slots, min_inlier_fraction,
+            inlier_slots,
+            n_slots,
+            min_inlier_fraction,
         )
         return _fallback_to_nearest(df, n_input)
 
@@ -254,10 +254,7 @@ def _resolve_residual_threshold(
             and np.isfinite(float(residual_threshold_ppm))
             and residual_threshold_ppm > 0
         ):
-            raise ValueError(
-                f"residual_threshold_ppm must be a positive finite number, "
-                f"got {residual_threshold_ppm!r}"
-            )
+            raise ValueError(f"residual_threshold_ppm must be a positive finite number, got {residual_threshold_ppm!r}")
         return float(residual_threshold_ppm)
 
     if (
@@ -272,22 +269,14 @@ def _resolve_residual_threshold(
     return _DEFAULT_RESIDUAL_THRESHOLD_PPM
 
 
-def _validate_hyperparameters(
-    min_samples: int, max_trials: int, min_inlier_fraction: float
-) -> None:
+def _validate_hyperparameters(min_samples: int, max_trials: int, min_inlier_fraction: float) -> None:
     if not (isinstance(min_samples, numbers.Integral) and min_samples >= 2):
-        raise ValueError(
-            f"min_samples must be an integer >= 2, got {min_samples!r}"
-        )
+        raise ValueError(f"min_samples must be an integer >= 2, got {min_samples!r}")
     if not (isinstance(max_trials, numbers.Integral) and max_trials >= 1):
-        raise ValueError(
-            f"max_trials must be an integer >= 1, got {max_trials!r}"
-        )
+        raise ValueError(f"max_trials must be an integer >= 1, got {max_trials!r}")
     if not (
         isinstance(min_inlier_fraction, numbers.Real)
         and np.isfinite(float(min_inlier_fraction))
         and 0.0 <= min_inlier_fraction <= 1.0
     ):
-        raise ValueError(
-            f"min_inlier_fraction must be a number in [0, 1], got {min_inlier_fraction!r}"
-        )
+        raise ValueError(f"min_inlier_fraction must be a number in [0, 1], got {min_inlier_fraction!r}")

--- a/spectrum_fundamentals/annotation/matchers/global_ransac.py
+++ b/spectrum_fundamentals/annotation/matchers/global_ransac.py
@@ -127,7 +127,8 @@ def global_ransac_resolver(
     if len(df) == 0:
         return pd.DataFrame(columns=df.columns), n_input
 
-    df["ppm_residual"] = 1e6 * (df["exp_mass"].to_numpy() - df["theoretical_mass"].to_numpy()) / df["theoretical_mass"].to_numpy()
+    theo_masses = df["theoretical_mass"].to_numpy()
+    df["ppm_residual"] = 1e6 * (df["exp_mass"].to_numpy() - theo_masses) / theo_masses
 
     if len(df) < min_samples:
         logger.info(

--- a/spectrum_fundamentals/annotation/matchers/nearest.py
+++ b/spectrum_fundamentals/annotation/matchers/nearest.py
@@ -22,6 +22,8 @@ def nearest_resolver(
     if len(df) == 0:
         return df, 0
     df["mass_diff"] = (df["exp_mass"] - df["theoretical_mass"]).abs()
+    df["ppm_error"] = df["mass_diff"] / df["theoretical_mass"] * 1e6
+    # ^ Scale-invariant mass deviation in ppm — used as rescoring feature for Percolator.
     df = df.sort_values(by="mass_diff", ascending=True)
     original_length = len(df.index)
     df = df.drop_duplicates(subset=["ion_type", "no", "charge"], keep="first")

--- a/spectrum_fundamentals/annotation/matchers/nearest.py
+++ b/spectrum_fundamentals/annotation/matchers/nearest.py
@@ -1,0 +1,28 @@
+"""Closest-m/z resolver — current Oktoberfest default behaviour."""
+
+import numpy as np
+import pandas as pd
+
+
+def nearest_resolver(
+    candidates: list[dict],
+    peaks_masses: np.ndarray | None = None,
+    peaks_intensity: np.ndarray | None = None,
+    unmod_sequence: str | None = None,
+    **kwargs,
+) -> tuple[pd.DataFrame, int]:
+    """Pick, per fragment slot, the candidate with the smallest |exp - theo| m/z.
+
+    Byte-identical to ``handle_multiple_matches(..., sort_by="mass_diff")``.
+    The ``peaks_*`` and ``unmod_sequence`` arguments are part of the resolver
+    contract for forward compatibility with global matchers; this resolver
+    does not use them.
+    """
+    df = pd.DataFrame(candidates)
+    if len(df) == 0:
+        return df, 0
+    df["mass_diff"] = (df["exp_mass"] - df["theoretical_mass"]).abs()
+    df = df.sort_values(by="mass_diff", ascending=True)
+    original_length = len(df.index)
+    df = df.drop_duplicates(subset=["ion_type", "no", "charge"], keep="first")
+    return df, original_length - len(df.index)

--- a/spectrum_fundamentals/metrics/percolator.py
+++ b/spectrum_fundamentals/metrics/percolator.py
@@ -312,6 +312,7 @@ class Percolator(Metric):
             for feature in ["mean_ppm_error", "max_ppm_error", "std_ppm_error"]:
                 if feature in self.metadata.columns:
                     self.metrics_val[feature] = self.metadata[feature]
+                    self.metrics_val[feature] = self.metrics_val[feature].fillna(self.metrics_val[feature].median())
 
         self.metrics_val["Charge1"] = (self.metadata["PRECURSOR_CHARGE"] == 1).astype(int)
         self.metrics_val["Charge2"] = (self.metadata["PRECURSOR_CHARGE"] == 2).astype(int)

--- a/spectrum_fundamentals/metrics/percolator.py
+++ b/spectrum_fundamentals/metrics/percolator.py
@@ -307,6 +307,11 @@ class Percolator(Metric):
             self.metrics_val["KR"] = self.metadata["SEQUENCE"].apply(Percolator.count_arginines_and_lysines)
             self.metrics_val["sequence_length"] = self.metadata["SEQUENCE"].apply(lambda x: len(x))
             self.metrics_val["Mass"] = self.metadata["CALCULATED_MASS"]  # this is the calculated mass used as a feature
+            # ppm_error features: per-PSM peak matching quality metrics. Only added if available
+            # TODO: handle NaN values before passing to Percolator (see annotation.py).
+            for feature in ["mean_ppm_error", "max_ppm_error", "std_ppm_error"]:
+                if feature in self.metadata.columns:
+                    self.metrics_val[feature] = self.metadata[feature]
 
         self.metrics_val["Charge1"] = (self.metadata["PRECURSOR_CHARGE"] == 1).astype(int)
         self.metrics_val["Charge2"] = (self.metadata["PRECURSOR_CHARGE"] == 2).astype(int)

--- a/tests/unit_tests/test_annotation.py
+++ b/tests/unit_tests/test_annotation.py
@@ -295,7 +295,7 @@ class TestAnnotationPipeline(unittest.TestCase):
             matched_peaks,
             sort_by="illegal",
         )
-        
+
     def test_annotate_spectra_returns_sc_features(self):
         """annotate_spectra always returns sc_features dict with ppm_error stats per PSM."""
         spectrum_input = pd.read_csv(

--- a/tests/unit_tests/test_annotation.py
+++ b/tests/unit_tests/test_annotation.py
@@ -108,6 +108,56 @@ class TestAnnotationPipeline(unittest.TestCase):
         result = annotation.annotate_spectra(spectrum_input)
         pd.testing.assert_frame_equal(expected_result, result)
 
+    def test_annotate_spectra_matching_method_nearest_is_default(self):
+        """matching_method='nearest' must reproduce the default behaviour exactly."""
+        spectrum_input = pd.read_csv(
+            Path(__file__).parent / "data/spectrum_input.csv",
+            index_col=0,
+            converters={"INTENSITIES": literal_eval, "MZ": literal_eval},
+        )
+        spectrum_input["INTENSITIES"] = spectrum_input["INTENSITIES"].map(lambda intensities: np.array(intensities))
+        spectrum_input["MZ"] = spectrum_input["MZ"].map(lambda mz: np.array(mz))
+
+        default = annotation.annotate_spectra(spectrum_input.copy())
+        explicit = annotation.annotate_spectra(spectrum_input.copy(), matching_method="nearest")
+        pd.testing.assert_frame_equal(default, explicit)
+
+    def test_annotate_spectra_global_ransac_runs(self):
+        """The global_ransac resolver runs end-to-end and yields a valid matrix."""
+        spectrum_input = pd.read_csv(
+            Path(__file__).parent / "data/spectrum_input.csv",
+            index_col=0,
+            converters={"INTENSITIES": literal_eval, "MZ": literal_eval},
+        )
+        spectrum_input["INTENSITIES"] = spectrum_input["INTENSITIES"].map(lambda intensities: np.array(intensities))
+        spectrum_input["MZ"] = spectrum_input["MZ"].map(lambda mz: np.array(mz))
+
+        default = annotation.annotate_spectra(spectrum_input.copy())
+        result = annotation.annotate_spectra(
+            spectrum_input.copy(),
+            matching_method="global_ransac",
+            mass_tolerance=20,
+            unit_mass_tolerance="ppm",
+            matching_method_params={"unique_peak": False},
+        )
+        # same shape/columns as the default path, finite intensities
+        self.assertEqual(len(result), len(default))
+        self.assertListEqual(list(result.columns), list(default.columns))
+        self.assertFalse(np.isnan(np.stack(result["INTENSITIES"].values)).any())
+
+    def test_annotate_spectra_unknown_matching_method_raises(self):
+        """An unregistered matching_method surfaces as a ValueError."""
+        spectrum_input = pd.read_csv(
+            Path(__file__).parent / "data/spectrum_input.csv",
+            index_col=0,
+            converters={"INTENSITIES": literal_eval, "MZ": literal_eval},
+        )
+        spectrum_input["INTENSITIES"] = spectrum_input["INTENSITIES"].map(lambda intensities: np.array(intensities))
+        spectrum_input["MZ"] = spectrum_input["MZ"].map(lambda mz: np.array(mz))
+
+        with self.assertRaises(ValueError):
+            annotation.annotate_spectra(spectrum_input, matching_method="not_a_matcher")
+
     def test_handle_multiple_matches(self):
         """Test handle_multiple_matches function."""
         # Example input data with multiple matches. They don't make biological sense but it tests

--- a/tests/unit_tests/test_annotation.py
+++ b/tests/unit_tests/test_annotation.py
@@ -145,6 +145,51 @@ class TestAnnotationPipeline(unittest.TestCase):
         self.assertListEqual(list(result.columns), list(default.columns))
         self.assertFalse(np.isnan(np.stack(result["INTENSITIES"].values)).any())
 
+    def test_annotate_spectra_dp_ladder_runs(self):
+        """The dp_ladder resolver runs end-to-end and yields a valid matrix."""
+        spectrum_input = pd.read_csv(
+            Path(__file__).parent / "data/spectrum_input.csv",
+            index_col=0,
+            converters={"INTENSITIES": literal_eval, "MZ": literal_eval},
+        )
+        spectrum_input["INTENSITIES"] = spectrum_input["INTENSITIES"].map(lambda intensities: np.array(intensities))
+        spectrum_input["MZ"] = spectrum_input["MZ"].map(lambda mz: np.array(mz))
+
+        default = annotation.annotate_spectra(spectrum_input.copy())
+        result = annotation.annotate_spectra(
+            spectrum_input.copy(),
+            matching_method="dp_ladder",
+            mass_tolerance=20,
+            unit_mass_tolerance="ppm",
+            matching_method_params={"ladder_weight": 2.0, "intensity_weight": 0.1},
+        )
+        # same shape/columns as the default path, finite intensities
+        self.assertEqual(len(result), len(default))
+        self.assertListEqual(list(result.columns), list(default.columns))
+        self.assertFalse(np.isnan(np.stack(result["INTENSITIES"].values)).any())
+
+    def test_annotate_spectra_dp_calibrated_runs(self):
+        """The dp_calibrated resolver runs end-to-end and yields a valid matrix."""
+        spectrum_input = pd.read_csv(
+            Path(__file__).parent / "data/spectrum_input.csv",
+            index_col=0,
+            converters={"INTENSITIES": literal_eval, "MZ": literal_eval},
+        )
+        spectrum_input["INTENSITIES"] = spectrum_input["INTENSITIES"].map(lambda intensities: np.array(intensities))
+        spectrum_input["MZ"] = spectrum_input["MZ"].map(lambda mz: np.array(mz))
+
+        default = annotation.annotate_spectra(spectrum_input.copy())
+        result = annotation.annotate_spectra(
+            spectrum_input.copy(),
+            matching_method="dp_calibrated",
+            mass_tolerance=20,
+            unit_mass_tolerance="ppm",
+            matching_method_params={"iterations": 2, "ladder_weight": 1.0},
+        )
+        self.assertEqual(len(result), len(default))
+        self.assertListEqual(list(result.columns), list(default.columns))
+        self.assertFalse(np.isnan(np.stack(result["INTENSITIES"].values)).any())
+
     def test_annotate_spectra_unknown_matching_method_raises(self):
         """An unregistered matching_method surfaces as a ValueError."""
         spectrum_input = pd.read_csv(

--- a/tests/unit_tests/test_annotation.py
+++ b/tests/unit_tests/test_annotation.py
@@ -28,7 +28,9 @@ class TestAnnotationPipeline(unittest.TestCase):
         spectrum_input["MZ"] = spectrum_input["MZ"].map(lambda mz: np.array(mz))
 
         result = annotation.annotate_spectra(spectrum_input)
-        pd.testing.assert_frame_equal(expected_result, result)
+        # Only assert columns present in legacy expected output.
+        # New per-PSM metrics (sc_features etc.) are tested separately.
+        pd.testing.assert_frame_equal(expected_result, result[expected_result.columns])
 
     def test_annotate_spectra_multifrag(self):
         """Test annotate spectra."""
@@ -47,7 +49,9 @@ class TestAnnotationPipeline(unittest.TestCase):
         spectrum_input["MZ"] = spectrum_input["MZ"].map(lambda mz: np.array(mz))
 
         result = annotation.annotate_spectra(spectrum_input, multifrag=True, fragmentation_method="ECD")
-        pd.testing.assert_frame_equal(expected_result, result)
+        # Only assert columns present in legacy expected output.
+        # New per-PSM metrics (sc_features etc.) are tested separately.
+        pd.testing.assert_frame_equal(expected_result, result[expected_result.columns])
 
     def test_annotate_spectra_with_custom_mods(self):
         """Test annotate spectra."""
@@ -67,7 +71,9 @@ class TestAnnotationPipeline(unittest.TestCase):
         custom_mods = {"[UNIMOD:4]": 57.0215, "[UNIMOD:35]": 15.99}
 
         result = annotation.annotate_spectra(un_annot_spectra=spectrum_input, custom_mods=custom_mods)
-        pd.testing.assert_frame_equal(expected_result, result)
+        # Only assert columns present in legacy expected output.
+        # New per-PSM metrics (sc_features etc.) are tested separately.
+        pd.testing.assert_frame_equal(expected_result, result[expected_result.columns])
 
     def test_annotate_spectra_noncl_xl(self):
         """Test annotate spectra non cleavable crosslinked peptides."""
@@ -106,7 +112,9 @@ class TestAnnotationPipeline(unittest.TestCase):
         spectrum_input["MZ"] = spectrum_input["MZ"].map(lambda mz: np.array(mz))
 
         result = annotation.annotate_spectra(spectrum_input)
-        pd.testing.assert_frame_equal(expected_result, result)
+        # Only assert columns present in legacy expected output.
+        # New per-PSM metrics (sc_features etc.) are tested separately.
+        pd.testing.assert_frame_equal(expected_result, result[expected_result.columns])
 
     def test_annotate_spectra_matching_method_nearest_is_default(self):
         """matching_method='nearest' must reproduce the default behaviour exactly."""
@@ -287,3 +295,23 @@ class TestAnnotationPipeline(unittest.TestCase):
             matched_peaks,
             sort_by="illegal",
         )
+        
+    def test_annotate_spectra_returns_sc_features(self):
+        """annotate_spectra always returns sc_features dict with ppm_error stats per PSM."""
+        spectrum_input = pd.read_csv(
+            Path(__file__).parent / "data/spectrum_input.csv",
+            index_col=0,
+            converters={"INTENSITIES": literal_eval, "MZ": literal_eval},
+        )
+        spectrum_input["INTENSITIES"] = spectrum_input["INTENSITIES"].map(lambda intensities: np.array(intensities))
+        spectrum_input["MZ"] = spectrum_input["MZ"].map(lambda mz: np.array(mz))
+
+        result = annotation.annotate_spectra(spectrum_input)
+
+        # sc_features column must always be present
+        self.assertIn("sc_features", result.columns)
+
+        # every PSM must contain exactly the expected keys
+        expected_keys = {"mean_ppm_error", "max_ppm_error", "std_ppm_error"}
+        for sc_feat in result["sc_features"]:
+            self.assertEqual(set(sc_feat.keys()), expected_keys)

--- a/tests/unit_tests/test_matchers.py
+++ b/tests/unit_tests/test_matchers.py
@@ -5,6 +5,14 @@ import pandas as pd
 
 from spectrum_fundamentals.annotation import annotation
 from spectrum_fundamentals.annotation.matchers import resolve_matches
+from spectrum_fundamentals.annotation.matchers.dp_calibrated import (
+    _fit_line_ols,
+    dp_calibrated_resolver,
+)
+from spectrum_fundamentals.annotation.matchers.dp_ladder import (
+    _resolve_ppm_scale,
+    dp_ladder_resolver,
+)
 from spectrum_fundamentals.annotation.matchers.global_ransac import (
     _resolve_residual_threshold,
     global_ransac_resolver,
@@ -70,6 +78,24 @@ class TestResolveMatchesDispatch(unittest.TestCase):
             "global_ransac", cands, None, None, "PEPTIDE", residual_threshold_ppm=5.0, random_state=0
         )
         direct, _ = global_ransac_resolver(cands, residual_threshold_ppm=5.0, random_state=0)
+        pd.testing.assert_frame_equal(
+            via_registry.reset_index(drop=True), direct.reset_index(drop=True)
+        )
+
+    def test_dispatch_dp_ladder(self):
+        """The dp_ladder matcher is reachable through the registry."""
+        cands = _line_candidates()
+        via_registry, _ = resolve_matches("dp_ladder", cands, None, None, "PEPTIDE", ppm_scale=10.0)
+        direct, _ = dp_ladder_resolver(cands, ppm_scale=10.0)
+        pd.testing.assert_frame_equal(
+            via_registry.reset_index(drop=True), direct.reset_index(drop=True)
+        )
+
+    def test_dispatch_dp_calibrated(self):
+        """The dp_calibrated matcher is reachable through the registry."""
+        cands = _line_candidates()
+        via_registry, _ = resolve_matches("dp_calibrated", cands, None, None, "PEPTIDE", ppm_scale=10.0)
+        direct, _ = dp_calibrated_resolver(cands, ppm_scale=10.0)
         pd.testing.assert_frame_equal(
             via_registry.reset_index(drop=True), direct.reset_index(drop=True)
         )
@@ -200,6 +226,364 @@ class TestGlobalRansacResolver(unittest.TestCase):
             with self.subTest(**kwargs):
                 with self.assertRaises(ValueError):
                     global_ransac_resolver(cands, **kwargs)
+
+
+def _b_ladder(error_ppm: float = 8.0) -> list[dict]:
+    """Four singly-charged b ions on a constant ppm drift line (theo 200..500)."""
+    return [
+        {"ion_type": "b", "no": k + 1, "charge": 1, "theoretical_mass": theo,
+         "exp_mass": _ppm(theo, error_ppm), "intensity": inten}
+        for k, (theo, inten) in enumerate([(200.0, 0.5), (300.0, 0.7), (400.0, 0.4), (500.0, 0.6)])
+    ]
+
+
+class TestDPLadderResolver(unittest.TestCase):
+    """Dynamic-programming matcher over the b/y ion ladder."""
+
+    def test_empty_and_none_candidates(self):
+        """None or empty candidates return an empty frame without running the DP."""
+        for arg in (None, []):
+            df, dropped = dp_ladder_resolver(arg)
+            self.assertTrue(df.empty)
+            self.assertEqual(dropped, 0)
+
+    def test_clean_ladder_matches_every_slot(self):
+        """A clean single-candidate ladder is matched in full, like nearest."""
+        cands = _b_ladder(error_ppm=3.0)
+        dp_df, dp_dropped = dp_ladder_resolver(cands)
+        near_df, _ = nearest_resolver(cands)
+        self.assertEqual(len(dp_df), len(near_df))  # nothing dropped
+        self.assertEqual(dp_dropped, 0)
+        self.assertEqual(
+            set(map(tuple, dp_df[["ion_type", "no", "charge"]].values.tolist())),
+            set(map(tuple, near_df[["ion_type", "no", "charge"]].values.tolist())),
+        )
+
+    def test_ladder_consistency_beats_absolute_closeness(self):
+        """On a drifted ladder, the DP keeps the gap-consistent peak where
+        nearest would grab a closer-to-theoretical noise peak."""
+        cands = _b_ladder(error_ppm=8.0)
+        # b3 gets a second candidate that is closer in absolute ppm (+1) but off
+        # the local +8 ppm drift line.
+        cands.append(
+            {"ion_type": "b", "no": 3, "charge": 1, "theoretical_mass": 400.0,
+             "exp_mass": _ppm(400.0, 1.0), "intensity": 0.9}
+        )
+        near_df, _ = nearest_resolver(cands)
+        near_b3 = near_df[(near_df["ion_type"] == "b") & (near_df["no"] == 3)]["exp_mass"].iloc[0]
+        self.assertAlmostEqual(near_b3, _ppm(400.0, 1.0))  # nearest grabs the off-line peak
+
+        dp_df, _ = dp_ladder_resolver(cands)
+        dp_b3 = dp_df[(dp_df["ion_type"] == "b") & (dp_df["no"] == 3)]["exp_mass"].iloc[0]
+        self.assertAlmostEqual(dp_b3, _ppm(400.0, 8.0))  # DP keeps the on-line peak
+
+    def test_ladder_inconsistent_peak_is_skipped(self):
+        """A lone in-window peak that breaks the ladder gap is dropped as noise."""
+        cands = _b_ladder(error_ppm=8.0)
+        cands.append(
+            {"ion_type": "b", "no": 5, "charge": 1, "theoretical_mass": 600.0,
+             "exp_mass": _ppm(600.0, 19.0), "intensity": 0.3}  # in 20 ppm window, off the line
+        )
+        dp_df, dropped = dp_ladder_resolver(cands)  # defaults: skip_penalty=1, ladder_weight=2
+        self.assertEqual(len(dp_df), 4)  # the four on-line slots
+        self.assertEqual(dropped, 1)
+        self.assertFalse(((dp_df["ion_type"] == "b") & (dp_df["no"] == 5)).any())
+
+    def test_missing_fragment_is_bridged(self):
+        """A gap in the ladder (absent b3) doesn't break consistency: the b2->b4
+        transition spans the missing residue and the present peaks stay matched."""
+        cands = [c for c in _b_ladder(error_ppm=8.0) if c["no"] != 3]
+        dp_df, dropped = dp_ladder_resolver(cands)
+        self.assertEqual(len(dp_df), 3)  # b1, b2, b4 all kept
+        self.assertEqual(dropped, 0)
+        self.assertEqual(sorted(dp_df["no"].tolist()), [1, 2, 4])
+
+    def test_monotonicity_prevents_peak_reuse_within_ladder(self):
+        """Two adjacent slots whose windows share one peak can't both claim it;
+        the ladder's monotonic m/z constraint forces uniqueness."""
+        shared = 250.0
+        cands = [
+            {"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 249.999,
+             "exp_mass": shared, "intensity": 0.5},
+            {"ion_type": "b", "no": 2, "charge": 1, "theoretical_mass": 250.001,
+             "exp_mass": shared, "intensity": 0.5},
+        ]
+        dp_df, _ = dp_ladder_resolver(cands)
+        self.assertFalse(dp_df["exp_mass"].duplicated().any())
+        self.assertLessEqual(len(dp_df), 1)
+
+    def test_unique_peak_dedup_across_ladders(self):
+        """unique_peak resolves a peak claimed by both a b ladder and a y ladder."""
+        shared = _ppm(400.0, 2.0)
+        cands = [
+            {"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 200.0,
+             "exp_mass": _ppm(200.0, 2.0), "intensity": 0.5},
+            {"ion_type": "b", "no": 2, "charge": 1, "theoretical_mass": 400.0,
+             "exp_mass": shared, "intensity": 0.5},
+            {"ion_type": "y", "no": 1, "charge": 1, "theoretical_mass": 400.0001,
+             "exp_mass": shared, "intensity": 0.5},
+            {"ion_type": "y", "no": 2, "charge": 1, "theoretical_mass": 600.0,
+             "exp_mass": _ppm(600.0, 2.0), "intensity": 0.5},
+        ]
+        unique_df, _ = dp_ladder_resolver(cands, unique_peak=True)
+        reuse_df, _ = dp_ladder_resolver(cands, unique_peak=False)
+        self.assertFalse(unique_df["exp_mass"].duplicated().any())
+        self.assertEqual((reuse_df["exp_mass"].round(6) == round(shared, 6)).sum(), 2)
+
+    def test_min_match_fraction_triggers_fallback(self):
+        """If the DP would drop too many slots, defer to nearest."""
+        cands = _b_ladder(error_ppm=8.0)
+        # Three of four slots are gross outliers the DP would skip on the ladder.
+        for c in cands[1:]:
+            c["exp_mass"] = _ppm(c["theoretical_mass"], 19.5)
+        floored_df, _ = dp_ladder_resolver(cands, ladder_weight=10.0, min_match_fraction=0.9)
+        self.assertEqual(len(floored_df), 4)  # nearest fills every slot
+        self.assertNotIn("ppm_residual", floored_df.columns)  # fallback strips diagnostics
+
+    def test_nonfinite_rows_dropped(self):
+        """NaN/inf/non-positive masses are dropped and counted."""
+        cands = _b_ladder(error_ppm=3.0) + [
+            {"ion_type": "b", "no": 6, "charge": 1, "theoretical_mass": np.nan,
+             "exp_mass": 600.0, "intensity": 0.1},
+            {"ion_type": "y", "no": 7, "charge": 1, "theoretical_mass": -5.0,
+             "exp_mass": 700.0, "intensity": 0.1},
+        ]
+        df, dropped = dp_ladder_resolver(cands)
+        self.assertEqual(len(df), 4)
+        self.assertEqual(dropped, 2)
+        self.assertTrue(np.isfinite(df["theoretical_mass"]).all())
+
+    def test_full_name_preserved(self):
+        """The multifrag full_name column is carried through to the output."""
+        cands = _b_ladder(error_ppm=3.0)
+        for i, c in enumerate(cands):
+            c["full_name"] = f"frag_{i}"
+        df, _ = dp_ladder_resolver(cands)
+        self.assertIn("full_name", df.columns)
+
+    def test_nonfinite_intensity_does_not_poison_cost(self):
+        """A NaN/inf intensity must not turn a candidate's cost into NaN (and so
+        silently drop a valid on-ladder peak), even at intensity_weight=0."""
+        for bad in (np.nan, np.inf):
+            with self.subTest(bad=bad):
+                cands = _b_ladder(error_ppm=3.0)
+                cands[2]["intensity"] = bad  # the b3 peak still sits on the ladder
+                for weight in (0.0, 0.5):
+                    df, _ = dp_ladder_resolver(cands, intensity_weight=weight)
+                    self.assertEqual(len(df), 4)  # b3 is kept, not dropped
+                    self.assertTrue(((df["ion_type"] == "b") & (df["no"] == 3)).any())
+
+    def test_ppm_residual_diagnostic_exposed(self):
+        """The resolver surfaces a ppm_residual column for downstream features."""
+        df, _ = dp_ladder_resolver(_b_ladder(error_ppm=3.0))
+        self.assertIn("ppm_residual", df.columns)
+
+    def test_missing_required_column_raises(self):
+        """Candidate rows missing a contract column raise ValueError."""
+        bad = [{"ion_type": "b", "no": 1, "charge": 1, "exp_mass": 200.0, "intensity": 0.5}]
+        with self.assertRaises(ValueError):
+            dp_ladder_resolver(bad)
+
+    def test_hyperparameter_validation(self):
+        """Out-of-range hyperparameters raise ValueError before running."""
+        cands = _b_ladder()
+        for kwargs in (
+            {"skip_penalty": 0},
+            {"skip_penalty": -1.0},
+            {"ladder_weight": -0.1},
+            {"intensity_weight": -1.0},
+            {"min_match_fraction": 1.5},
+            {"min_match_fraction": -0.1},
+            {"ppm_scale": 0},
+            {"ppm_scale": float("inf")},
+        ):
+            with self.subTest(**kwargs):
+                with self.assertRaises(ValueError):
+                    dp_ladder_resolver(cands, **kwargs)
+
+
+class TestDpCalibratedResolver(unittest.TestCase):
+    """RANSAC drift fit + ladder DP combined."""
+
+    def test_empty_and_none_candidates(self):
+        for arg in (None, []):
+            df, dropped = dp_calibrated_resolver(arg)
+            self.assertTrue(df.empty)
+            self.assertEqual(dropped, 0)
+
+    def test_drift_is_calibrated_away(self):
+        """A constant +12 ppm drift is captured by the fit: every matched peak
+        ends up ~on the line (dev_from_line ~ 0) and the ladder is matched in full."""
+        df, dropped = dp_calibrated_resolver(
+            _b_ladder(error_ppm=12.0), mass_tolerance=20, unit_mass_tolerance="ppm"
+        )
+        self.assertEqual(len(df), 4)
+        self.assertEqual(dropped, 0)
+        self.assertIn("dev_from_line", df.columns)
+        self.assertIn("ppm_residual", df.columns)
+        self.assertTrue(np.allclose(df["dev_from_line"].to_numpy(), 0.0, atol=1e-3))
+        # the raw residual still reflects the true +12 drift
+        self.assertTrue(np.allclose(df["ppm_residual"].to_numpy(), 12.0, atol=1e-3))
+
+    def test_on_line_peak_chosen_over_near_theoretical_noise(self):
+        """Under drift, the de-drifted emission keeps the calibration-consistent
+        peak where 'closest to theoretical' would grab a near-zero-ppm noise peak."""
+        cands = _b_ladder(error_ppm=12.0)
+        cands.append(
+            {"ion_type": "b", "no": 3, "charge": 1, "theoretical_mass": 400.0,
+             "exp_mass": _ppm(400.0, 1.0), "intensity": 0.9}  # near theoretical, off the drift line
+        )
+        # nearest grabs the +1 ppm peak; dp_calibrated keeps the on-line +12 peak
+        near_df, _ = nearest_resolver(cands)
+        near_b3 = near_df[(near_df["ion_type"] == "b") & (near_df["no"] == 3)]["exp_mass"].iloc[0]
+        self.assertAlmostEqual(near_b3, _ppm(400.0, 1.0))
+
+        df, _ = dp_calibrated_resolver(cands, mass_tolerance=20, unit_mass_tolerance="ppm")
+        cal_b3 = df[(df["ion_type"] == "b") & (df["no"] == 3)]["exp_mass"].iloc[0]
+        self.assertAlmostEqual(cal_b3, _ppm(400.0, 12.0))
+
+    def test_falls_back_to_raw_ladder_when_no_line(self):
+        """Too few candidates to fit a drift line -> raw ladder DP, still matches."""
+        single = [{"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 200.0,
+                   "exp_mass": _ppm(200.0, 3.0), "intensity": 0.5}]
+        df, dropped = dp_calibrated_resolver(single, min_samples=2)
+        self.assertEqual(len(df), 1)
+        self.assertEqual(dropped, 0)
+        # no line -> dev_from_line is just the raw residual
+        self.assertTrue(np.allclose(df["dev_from_line"].to_numpy(), df["ppm_residual"].to_numpy()))
+
+    def test_min_inlier_fraction_forces_raw_ladder(self):
+        """A fit that explains too few slots is rejected; emission stays raw."""
+        cands = [
+            {"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 200.0,
+             "exp_mass": _ppm(200.0, 15.0), "intensity": 0.5},
+            {"ion_type": "b", "no": 2, "charge": 1, "theoretical_mass": 300.0,
+             "exp_mass": _ppm(300.0, 15.0), "intensity": 0.5},
+            {"ion_type": "b", "no": 3, "charge": 1, "theoretical_mass": 400.0,
+             "exp_mass": _ppm(400.0, 15.0), "intensity": 0.5},
+            {"ion_type": "b", "no": 4, "charge": 1, "theoretical_mass": 500.0,
+             "exp_mass": _ppm(500.0, 1.0), "intensity": 0.5},  # off the +15 line
+        ]
+        # Tight inlier band so no sloped line can absorb the off-line point:
+        # the best consensus covers only 3/4 slots, below the 1.0 floor.
+        df, _ = dp_calibrated_resolver(
+            cands, ppm_scale=20, residual_threshold_ppm=2.0, min_inlier_fraction=1.0
+        )
+        # line rejected -> dev_from_line == raw ppm_residual on whatever was matched
+        self.assertGreaterEqual(len(df), 1)
+        self.assertTrue(np.allclose(df["dev_from_line"].to_numpy(), df["ppm_residual"].to_numpy()))
+
+    def test_iterations_are_deterministic_and_converge(self):
+        """Extra EM passes don't crash and converge to the single-pass result here."""
+        cands = _b_ladder(error_ppm=8.0)
+        one, _ = dp_calibrated_resolver(cands, mass_tolerance=20, unit_mass_tolerance="ppm", iterations=1)
+        many, _ = dp_calibrated_resolver(cands, mass_tolerance=20, unit_mass_tolerance="ppm", iterations=5)
+        self.assertEqual(
+            set(map(tuple, one[["ion_type", "no", "charge"]].values.tolist())),
+            set(map(tuple, many[["ion_type", "no", "charge"]].values.tolist())),
+        )
+
+    def test_unique_peak_dedup_across_ladders(self):
+        shared = _ppm(400.0, 2.0)
+        cands = [
+            {"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 200.0,
+             "exp_mass": _ppm(200.0, 2.0), "intensity": 0.5},
+            {"ion_type": "b", "no": 2, "charge": 1, "theoretical_mass": 400.0,
+             "exp_mass": shared, "intensity": 0.5},
+            {"ion_type": "y", "no": 1, "charge": 1, "theoretical_mass": 400.0001,
+             "exp_mass": shared, "intensity": 0.5},
+            {"ion_type": "y", "no": 2, "charge": 1, "theoretical_mass": 600.0,
+             "exp_mass": _ppm(600.0, 2.0), "intensity": 0.5},
+        ]
+        unique_df, _ = dp_calibrated_resolver(cands, mass_tolerance=20, unit_mass_tolerance="ppm", unique_peak=True)
+        reuse_df, _ = dp_calibrated_resolver(cands, mass_tolerance=20, unit_mass_tolerance="ppm", unique_peak=False)
+        self.assertFalse(unique_df["exp_mass"].duplicated().any())
+        self.assertEqual((reuse_df["exp_mass"].round(6) == round(shared, 6)).sum(), 2)
+
+    def test_nonfinite_rows_dropped(self):
+        cands = _b_ladder(error_ppm=3.0) + [
+            {"ion_type": "b", "no": 6, "charge": 1, "theoretical_mass": np.nan,
+             "exp_mass": 600.0, "intensity": 0.1},
+            {"ion_type": "y", "no": 7, "charge": 1, "theoretical_mass": -5.0,
+             "exp_mass": 700.0, "intensity": 0.1},
+        ]
+        df, dropped = dp_calibrated_resolver(cands, mass_tolerance=20, unit_mass_tolerance="ppm")
+        self.assertEqual(len(df), 4)
+        self.assertEqual(dropped, 2)
+        self.assertTrue(np.isfinite(df["theoretical_mass"]).all())
+
+    def test_nonfinite_intensity_does_not_poison_cost(self):
+        cands = _b_ladder(error_ppm=3.0)
+        cands[2]["intensity"] = np.nan
+        df, _ = dp_calibrated_resolver(
+            cands, mass_tolerance=20, unit_mass_tolerance="ppm", intensity_weight=0.5
+        )
+        self.assertEqual(len(df), 4)
+        self.assertTrue(((df["ion_type"] == "b") & (df["no"] == 3)).any())
+
+    def test_full_name_preserved(self):
+        cands = _b_ladder(error_ppm=3.0)
+        for i, c in enumerate(cands):
+            c["full_name"] = f"frag_{i}"
+        df, _ = dp_calibrated_resolver(cands, mass_tolerance=20, unit_mass_tolerance="ppm")
+        self.assertIn("full_name", df.columns)
+
+    def test_missing_required_column_raises(self):
+        bad = [{"ion_type": "b", "no": 1, "charge": 1, "exp_mass": 200.0, "intensity": 0.5}]
+        with self.assertRaises(ValueError):
+            dp_calibrated_resolver(bad)
+
+    def test_hyperparameter_validation(self):
+        cands = _b_ladder()
+        for kwargs in (
+            {"skip_penalty": 0},
+            {"ladder_weight": -0.1},
+            {"min_match_fraction": 1.5},
+            {"min_samples": 1},
+            {"max_trials": 0},
+            {"min_inlier_fraction": 1.5},
+            {"iterations": 0},
+            {"ppm_scale": 0},
+            {"residual_threshold_ppm": -3.0},
+        ):
+            with self.subTest(**kwargs):
+                with self.assertRaises(ValueError):
+                    dp_calibrated_resolver(cands, **kwargs)
+
+
+class TestFitLineOls(unittest.TestCase):
+    """The OLS re-fit helper used by the EM iterations."""
+
+    def test_recovers_line(self):
+        theo = np.array([200.0, 300.0, 400.0, 500.0])
+        ppm = 5.0 + 0.01 * theo  # a=5, b=0.01
+        a, b = _fit_line_ols(theo, ppm)
+        self.assertAlmostEqual(a, 5.0, places=6)
+        self.assertAlmostEqual(b, 0.01, places=8)
+
+    def test_degenerate_inputs_return_none(self):
+        self.assertIsNone(_fit_line_ols(np.array([200.0]), np.array([5.0])))  # one point
+        self.assertIsNone(_fit_line_ols(np.array([200.0, 200.0]), np.array([5.0, 6.0])))  # one distinct x
+
+
+class TestPpmScaleDerivation(unittest.TestCase):
+    """Tolerance-aware default for the DP ppm scale."""
+
+    def test_explicit_value_wins(self):
+        self.assertEqual(_resolve_ppm_scale(8.0, 20.0, "ppm"), 8.0)
+
+    def test_derived_from_ppm_tolerance(self):
+        self.assertEqual(_resolve_ppm_scale(None, 20.0, "ppm"), 20.0)
+
+    def test_da_tolerance_uses_fixed_default(self):
+        self.assertEqual(_resolve_ppm_scale(None, 0.02, "da"), 20.0)
+
+    def test_missing_tolerance_uses_fixed_default(self):
+        self.assertEqual(_resolve_ppm_scale(None, None, None), 20.0)
+
+    def test_invalid_explicit_value_raises(self):
+        with self.assertRaises(ValueError):
+            _resolve_ppm_scale(-1.0, None, None)
 
 
 class TestResidualThresholdDerivation(unittest.TestCase):

--- a/tests/unit_tests/test_matchers.py
+++ b/tests/unit_tests/test_matchers.py
@@ -77,7 +77,6 @@ class TestNearestResolver(unittest.TestCase):
         legacy_df, legacy_dropped = annotation.handle_multiple_matches(matched_peaks, sort_by="mass_diff")
         resolver_df, resolver_dropped = nearest_resolver(matched_peaks)
 
-        pd.testing.assert_frame_equal(legacy_df, resolver_df)
         # ppm_error and future sc_features columns are not part of the legacy
         # handle_multiple_matches output — only compare the shared columns.
         pd.testing.assert_frame_equal(legacy_df, resolver_df[legacy_df.columns])

--- a/tests/unit_tests/test_matchers.py
+++ b/tests/unit_tests/test_matchers.py
@@ -28,14 +28,38 @@ def _ppm(theoretical_mass: float, error_ppm: float) -> float:
 def _line_candidates(error_ppm: float = 3.0) -> list[dict]:
     """Four fragment slots whose true peaks all sit on a constant ppm drift line."""
     return [
-        {"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 200.0,
-         "exp_mass": _ppm(200.0, error_ppm), "intensity": 0.5},
-        {"ion_type": "y", "no": 1, "charge": 1, "theoretical_mass": 400.0,
-         "exp_mass": _ppm(400.0, error_ppm), "intensity": 0.7},
-        {"ion_type": "b", "no": 2, "charge": 1, "theoretical_mass": 600.0,
-         "exp_mass": _ppm(600.0, error_ppm), "intensity": 0.4},
-        {"ion_type": "y", "no": 2, "charge": 1, "theoretical_mass": 800.0,
-         "exp_mass": _ppm(800.0, error_ppm), "intensity": 0.6},
+        {
+            "ion_type": "b",
+            "no": 1,
+            "charge": 1,
+            "theoretical_mass": 200.0,
+            "exp_mass": _ppm(200.0, error_ppm),
+            "intensity": 0.5,
+        },
+        {
+            "ion_type": "y",
+            "no": 1,
+            "charge": 1,
+            "theoretical_mass": 400.0,
+            "exp_mass": _ppm(400.0, error_ppm),
+            "intensity": 0.7,
+        },
+        {
+            "ion_type": "b",
+            "no": 2,
+            "charge": 1,
+            "theoretical_mass": 600.0,
+            "exp_mass": _ppm(600.0, error_ppm),
+            "intensity": 0.4,
+        },
+        {
+            "ion_type": "y",
+            "no": 2,
+            "charge": 1,
+            "theoretical_mass": 800.0,
+            "exp_mass": _ppm(800.0, error_ppm),
+            "intensity": 0.6,
+        },
     ]
 
 
@@ -78,27 +102,21 @@ class TestResolveMatchesDispatch(unittest.TestCase):
             "global_ransac", cands, None, None, "PEPTIDE", residual_threshold_ppm=5.0, random_state=0
         )
         direct, _ = global_ransac_resolver(cands, residual_threshold_ppm=5.0, random_state=0)
-        pd.testing.assert_frame_equal(
-            via_registry.reset_index(drop=True), direct.reset_index(drop=True)
-        )
+        pd.testing.assert_frame_equal(via_registry.reset_index(drop=True), direct.reset_index(drop=True))
 
     def test_dispatch_dp_ladder(self):
         """The dp_ladder matcher is reachable through the registry."""
         cands = _line_candidates()
         via_registry, _ = resolve_matches("dp_ladder", cands, None, None, "PEPTIDE", ppm_scale=10.0)
         direct, _ = dp_ladder_resolver(cands, ppm_scale=10.0)
-        pd.testing.assert_frame_equal(
-            via_registry.reset_index(drop=True), direct.reset_index(drop=True)
-        )
+        pd.testing.assert_frame_equal(via_registry.reset_index(drop=True), direct.reset_index(drop=True))
 
     def test_dispatch_dp_calibrated(self):
         """The dp_calibrated matcher is reachable through the registry."""
         cands = _line_candidates()
         via_registry, _ = resolve_matches("dp_calibrated", cands, None, None, "PEPTIDE", ppm_scale=10.0)
         direct, _ = dp_calibrated_resolver(cands, ppm_scale=10.0)
-        pd.testing.assert_frame_equal(
-            via_registry.reset_index(drop=True), direct.reset_index(drop=True)
-        )
+        pd.testing.assert_frame_equal(via_registry.reset_index(drop=True), direct.reset_index(drop=True))
 
 
 class TestGlobalRansacResolver(unittest.TestCase):
@@ -115,10 +133,22 @@ class TestGlobalRansacResolver(unittest.TestCase):
         """The fit keeps the on-line matches and rejects peaks off the drift line."""
         cands = _line_candidates(error_ppm=3.0)
         noise = [
-            {"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 200.0,
-             "exp_mass": _ppm(200.0, -18.0), "intensity": 0.9},  # same slot as a real match, far off
-            {"ion_type": "y", "no": 2, "charge": 1, "theoretical_mass": 800.0,
-             "exp_mass": _ppm(800.0, 19.0), "intensity": 0.2},   # same slot, far off
+            {
+                "ion_type": "b",
+                "no": 1,
+                "charge": 1,
+                "theoretical_mass": 200.0,
+                "exp_mass": _ppm(200.0, -18.0),
+                "intensity": 0.9,
+            },  # same slot as a real match, far off
+            {
+                "ion_type": "y",
+                "no": 2,
+                "charge": 1,
+                "theoretical_mass": 800.0,
+                "exp_mass": _ppm(800.0, 19.0),
+                "intensity": 0.2,
+            },  # same slot, far off
         ]
         df, dropped = global_ransac_resolver(cands + noise, residual_threshold_ppm=5.0)
 
@@ -135,17 +165,33 @@ class TestGlobalRansacResolver(unittest.TestCase):
         """unique_peak controls whether one observed peak may fill several slots."""
         shared = _ppm(800.0, 2.0)
         cands = [
-            {"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 200.0,
-             "exp_mass": _ppm(200.0, 2.0), "intensity": 0.5},
-            {"ion_type": "y", "no": 1, "charge": 1, "theoretical_mass": 400.0,
-             "exp_mass": _ppm(400.0, 2.0), "intensity": 0.5},
-            {"ion_type": "b", "no": 2, "charge": 1, "theoretical_mass": 600.0,
-             "exp_mass": _ppm(600.0, 2.0), "intensity": 0.5},
+            {
+                "ion_type": "b",
+                "no": 1,
+                "charge": 1,
+                "theoretical_mass": 200.0,
+                "exp_mass": _ppm(200.0, 2.0),
+                "intensity": 0.5,
+            },
+            {
+                "ion_type": "y",
+                "no": 1,
+                "charge": 1,
+                "theoretical_mass": 400.0,
+                "exp_mass": _ppm(400.0, 2.0),
+                "intensity": 0.5,
+            },
+            {
+                "ion_type": "b",
+                "no": 2,
+                "charge": 1,
+                "theoretical_mass": 600.0,
+                "exp_mass": _ppm(600.0, 2.0),
+                "intensity": 0.5,
+            },
             # two distinct slots that matched the same observed peak
-            {"ion_type": "b", "no": 4, "charge": 1, "theoretical_mass": 800.0,
-             "exp_mass": shared, "intensity": 0.5},
-            {"ion_type": "y", "no": 7, "charge": 2, "theoretical_mass": 800.0008,
-             "exp_mass": shared, "intensity": 0.5},
+            {"ion_type": "b", "no": 4, "charge": 1, "theoretical_mass": 800.0, "exp_mass": shared, "intensity": 0.5},
+            {"ion_type": "y", "no": 7, "charge": 2, "theoretical_mass": 800.0008, "exp_mass": shared, "intensity": 0.5},
         ]
         unique_df, _ = global_ransac_resolver(cands, residual_threshold_ppm=5.0, unique_peak=True)
         reuse_df, _ = global_ransac_resolver(cands, residual_threshold_ppm=5.0, unique_peak=False)
@@ -159,8 +205,16 @@ class TestGlobalRansacResolver(unittest.TestCase):
 
     def test_fallback_below_min_samples(self):
         """Fewer valid candidates than min_samples defers to nearest."""
-        single = [{"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 200.0,
-                   "exp_mass": _ppm(200.0, 3.0), "intensity": 0.5}]
+        single = [
+            {
+                "ion_type": "b",
+                "no": 1,
+                "charge": 1,
+                "theoretical_mass": 200.0,
+                "exp_mass": _ppm(200.0, 3.0),
+                "intensity": 0.5,
+            }
+        ]
         df, dropped = global_ransac_resolver(single, min_samples=2)
         self.assertEqual(len(df), 1)
         self.assertEqual(dropped, 0)
@@ -168,12 +222,9 @@ class TestGlobalRansacResolver(unittest.TestCase):
     def test_nonfinite_rows_dropped(self):
         """NaN/inf/non-positive masses are dropped and counted in n_dropped."""
         cands = _line_candidates(error_ppm=3.0) + [
-            {"ion_type": "b", "no": 3, "charge": 1, "theoretical_mass": np.nan,
-             "exp_mass": 300.0, "intensity": 0.1},
-            {"ion_type": "b", "no": 4, "charge": 1, "theoretical_mass": np.inf,
-             "exp_mass": 400.0, "intensity": 0.1},
-            {"ion_type": "y", "no": 5, "charge": 1, "theoretical_mass": -10.0,
-             "exp_mass": 500.0, "intensity": 0.1},
+            {"ion_type": "b", "no": 3, "charge": 1, "theoretical_mass": np.nan, "exp_mass": 300.0, "intensity": 0.1},
+            {"ion_type": "b", "no": 4, "charge": 1, "theoretical_mass": np.inf, "exp_mass": 400.0, "intensity": 0.1},
+            {"ion_type": "y", "no": 5, "charge": 1, "theoretical_mass": -10.0, "exp_mass": 500.0, "intensity": 0.1},
         ]
         df, dropped = global_ransac_resolver(cands, residual_threshold_ppm=5.0)
         self.assertEqual(len(df), 4)  # only the four valid on-line slots survive
@@ -231,8 +282,14 @@ class TestGlobalRansacResolver(unittest.TestCase):
 def _b_ladder(error_ppm: float = 8.0) -> list[dict]:
     """Four singly-charged b ions on a constant ppm drift line (theo 200..500)."""
     return [
-        {"ion_type": "b", "no": k + 1, "charge": 1, "theoretical_mass": theo,
-         "exp_mass": _ppm(theo, error_ppm), "intensity": inten}
+        {
+            "ion_type": "b",
+            "no": k + 1,
+            "charge": 1,
+            "theoretical_mass": theo,
+            "exp_mass": _ppm(theo, error_ppm),
+            "intensity": inten,
+        }
         for k, (theo, inten) in enumerate([(200.0, 0.5), (300.0, 0.7), (400.0, 0.4), (500.0, 0.6)])
     ]
 
@@ -266,8 +323,14 @@ class TestDPLadderResolver(unittest.TestCase):
         # b3 gets a second candidate that is closer in absolute ppm (+1) but off
         # the local +8 ppm drift line.
         cands.append(
-            {"ion_type": "b", "no": 3, "charge": 1, "theoretical_mass": 400.0,
-             "exp_mass": _ppm(400.0, 1.0), "intensity": 0.9}
+            {
+                "ion_type": "b",
+                "no": 3,
+                "charge": 1,
+                "theoretical_mass": 400.0,
+                "exp_mass": _ppm(400.0, 1.0),
+                "intensity": 0.9,
+            }
         )
         near_df, _ = nearest_resolver(cands)
         near_b3 = near_df[(near_df["ion_type"] == "b") & (near_df["no"] == 3)]["exp_mass"].iloc[0]
@@ -281,8 +344,14 @@ class TestDPLadderResolver(unittest.TestCase):
         """A lone in-window peak that breaks the ladder gap is dropped as noise."""
         cands = _b_ladder(error_ppm=8.0)
         cands.append(
-            {"ion_type": "b", "no": 5, "charge": 1, "theoretical_mass": 600.0,
-             "exp_mass": _ppm(600.0, 19.0), "intensity": 0.3}  # in 20 ppm window, off the line
+            {
+                "ion_type": "b",
+                "no": 5,
+                "charge": 1,
+                "theoretical_mass": 600.0,
+                "exp_mass": _ppm(600.0, 19.0),
+                "intensity": 0.3,
+            }  # in 20 ppm window, off the line
         )
         dp_df, dropped = dp_ladder_resolver(cands)  # defaults: skip_penalty=1, ladder_weight=2
         self.assertEqual(len(dp_df), 4)  # the four on-line slots
@@ -303,10 +372,8 @@ class TestDPLadderResolver(unittest.TestCase):
         the ladder's monotonic m/z constraint forces uniqueness."""
         shared = 250.0
         cands = [
-            {"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 249.999,
-             "exp_mass": shared, "intensity": 0.5},
-            {"ion_type": "b", "no": 2, "charge": 1, "theoretical_mass": 250.001,
-             "exp_mass": shared, "intensity": 0.5},
+            {"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 249.999, "exp_mass": shared, "intensity": 0.5},
+            {"ion_type": "b", "no": 2, "charge": 1, "theoretical_mass": 250.001, "exp_mass": shared, "intensity": 0.5},
         ]
         dp_df, _ = dp_ladder_resolver(cands)
         self.assertFalse(dp_df["exp_mass"].duplicated().any())
@@ -316,14 +383,24 @@ class TestDPLadderResolver(unittest.TestCase):
         """unique_peak resolves a peak claimed by both a b ladder and a y ladder."""
         shared = _ppm(400.0, 2.0)
         cands = [
-            {"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 200.0,
-             "exp_mass": _ppm(200.0, 2.0), "intensity": 0.5},
-            {"ion_type": "b", "no": 2, "charge": 1, "theoretical_mass": 400.0,
-             "exp_mass": shared, "intensity": 0.5},
-            {"ion_type": "y", "no": 1, "charge": 1, "theoretical_mass": 400.0001,
-             "exp_mass": shared, "intensity": 0.5},
-            {"ion_type": "y", "no": 2, "charge": 1, "theoretical_mass": 600.0,
-             "exp_mass": _ppm(600.0, 2.0), "intensity": 0.5},
+            {
+                "ion_type": "b",
+                "no": 1,
+                "charge": 1,
+                "theoretical_mass": 200.0,
+                "exp_mass": _ppm(200.0, 2.0),
+                "intensity": 0.5,
+            },
+            {"ion_type": "b", "no": 2, "charge": 1, "theoretical_mass": 400.0, "exp_mass": shared, "intensity": 0.5},
+            {"ion_type": "y", "no": 1, "charge": 1, "theoretical_mass": 400.0001, "exp_mass": shared, "intensity": 0.5},
+            {
+                "ion_type": "y",
+                "no": 2,
+                "charge": 1,
+                "theoretical_mass": 600.0,
+                "exp_mass": _ppm(600.0, 2.0),
+                "intensity": 0.5,
+            },
         ]
         unique_df, _ = dp_ladder_resolver(cands, unique_peak=True)
         reuse_df, _ = dp_ladder_resolver(cands, unique_peak=False)
@@ -343,10 +420,8 @@ class TestDPLadderResolver(unittest.TestCase):
     def test_nonfinite_rows_dropped(self):
         """NaN/inf/non-positive masses are dropped and counted."""
         cands = _b_ladder(error_ppm=3.0) + [
-            {"ion_type": "b", "no": 6, "charge": 1, "theoretical_mass": np.nan,
-             "exp_mass": 600.0, "intensity": 0.1},
-            {"ion_type": "y", "no": 7, "charge": 1, "theoretical_mass": -5.0,
-             "exp_mass": 700.0, "intensity": 0.1},
+            {"ion_type": "b", "no": 6, "charge": 1, "theoretical_mass": np.nan, "exp_mass": 600.0, "intensity": 0.1},
+            {"ion_type": "y", "no": 7, "charge": 1, "theoretical_mass": -5.0, "exp_mass": 700.0, "intensity": 0.1},
         ]
         df, dropped = dp_ladder_resolver(cands)
         self.assertEqual(len(df), 4)
@@ -414,9 +489,7 @@ class TestDpCalibratedResolver(unittest.TestCase):
     def test_drift_is_calibrated_away(self):
         """A constant +12 ppm drift is captured by the fit: every matched peak
         ends up ~on the line (dev_from_line ~ 0) and the ladder is matched in full."""
-        df, dropped = dp_calibrated_resolver(
-            _b_ladder(error_ppm=12.0), mass_tolerance=20, unit_mass_tolerance="ppm"
-        )
+        df, dropped = dp_calibrated_resolver(_b_ladder(error_ppm=12.0), mass_tolerance=20, unit_mass_tolerance="ppm")
         self.assertEqual(len(df), 4)
         self.assertEqual(dropped, 0)
         self.assertIn("dev_from_line", df.columns)
@@ -430,8 +503,14 @@ class TestDpCalibratedResolver(unittest.TestCase):
         peak where 'closest to theoretical' would grab a near-zero-ppm noise peak."""
         cands = _b_ladder(error_ppm=12.0)
         cands.append(
-            {"ion_type": "b", "no": 3, "charge": 1, "theoretical_mass": 400.0,
-             "exp_mass": _ppm(400.0, 1.0), "intensity": 0.9}  # near theoretical, off the drift line
+            {
+                "ion_type": "b",
+                "no": 3,
+                "charge": 1,
+                "theoretical_mass": 400.0,
+                "exp_mass": _ppm(400.0, 1.0),
+                "intensity": 0.9,
+            }  # near theoretical, off the drift line
         )
         # nearest grabs the +1 ppm peak; dp_calibrated keeps the on-line +12 peak
         near_df, _ = nearest_resolver(cands)
@@ -444,8 +523,16 @@ class TestDpCalibratedResolver(unittest.TestCase):
 
     def test_falls_back_to_raw_ladder_when_no_line(self):
         """Too few candidates to fit a drift line -> raw ladder DP, still matches."""
-        single = [{"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 200.0,
-                   "exp_mass": _ppm(200.0, 3.0), "intensity": 0.5}]
+        single = [
+            {
+                "ion_type": "b",
+                "no": 1,
+                "charge": 1,
+                "theoretical_mass": 200.0,
+                "exp_mass": _ppm(200.0, 3.0),
+                "intensity": 0.5,
+            }
+        ]
         df, dropped = dp_calibrated_resolver(single, min_samples=2)
         self.assertEqual(len(df), 1)
         self.assertEqual(dropped, 0)
@@ -455,20 +542,42 @@ class TestDpCalibratedResolver(unittest.TestCase):
     def test_min_inlier_fraction_forces_raw_ladder(self):
         """A fit that explains too few slots is rejected; emission stays raw."""
         cands = [
-            {"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 200.0,
-             "exp_mass": _ppm(200.0, 15.0), "intensity": 0.5},
-            {"ion_type": "b", "no": 2, "charge": 1, "theoretical_mass": 300.0,
-             "exp_mass": _ppm(300.0, 15.0), "intensity": 0.5},
-            {"ion_type": "b", "no": 3, "charge": 1, "theoretical_mass": 400.0,
-             "exp_mass": _ppm(400.0, 15.0), "intensity": 0.5},
-            {"ion_type": "b", "no": 4, "charge": 1, "theoretical_mass": 500.0,
-             "exp_mass": _ppm(500.0, 1.0), "intensity": 0.5},  # off the +15 line
+            {
+                "ion_type": "b",
+                "no": 1,
+                "charge": 1,
+                "theoretical_mass": 200.0,
+                "exp_mass": _ppm(200.0, 15.0),
+                "intensity": 0.5,
+            },
+            {
+                "ion_type": "b",
+                "no": 2,
+                "charge": 1,
+                "theoretical_mass": 300.0,
+                "exp_mass": _ppm(300.0, 15.0),
+                "intensity": 0.5,
+            },
+            {
+                "ion_type": "b",
+                "no": 3,
+                "charge": 1,
+                "theoretical_mass": 400.0,
+                "exp_mass": _ppm(400.0, 15.0),
+                "intensity": 0.5,
+            },
+            {
+                "ion_type": "b",
+                "no": 4,
+                "charge": 1,
+                "theoretical_mass": 500.0,
+                "exp_mass": _ppm(500.0, 1.0),
+                "intensity": 0.5,
+            },  # off the +15 line
         ]
         # Tight inlier band so no sloped line can absorb the off-line point:
         # the best consensus covers only 3/4 slots, below the 1.0 floor.
-        df, _ = dp_calibrated_resolver(
-            cands, ppm_scale=20, residual_threshold_ppm=2.0, min_inlier_fraction=1.0
-        )
+        df, _ = dp_calibrated_resolver(cands, ppm_scale=20, residual_threshold_ppm=2.0, min_inlier_fraction=1.0)
         # line rejected -> dev_from_line == raw ppm_residual on whatever was matched
         self.assertGreaterEqual(len(df), 1)
         self.assertTrue(np.allclose(df["dev_from_line"].to_numpy(), df["ppm_residual"].to_numpy()))
@@ -486,14 +595,24 @@ class TestDpCalibratedResolver(unittest.TestCase):
     def test_unique_peak_dedup_across_ladders(self):
         shared = _ppm(400.0, 2.0)
         cands = [
-            {"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 200.0,
-             "exp_mass": _ppm(200.0, 2.0), "intensity": 0.5},
-            {"ion_type": "b", "no": 2, "charge": 1, "theoretical_mass": 400.0,
-             "exp_mass": shared, "intensity": 0.5},
-            {"ion_type": "y", "no": 1, "charge": 1, "theoretical_mass": 400.0001,
-             "exp_mass": shared, "intensity": 0.5},
-            {"ion_type": "y", "no": 2, "charge": 1, "theoretical_mass": 600.0,
-             "exp_mass": _ppm(600.0, 2.0), "intensity": 0.5},
+            {
+                "ion_type": "b",
+                "no": 1,
+                "charge": 1,
+                "theoretical_mass": 200.0,
+                "exp_mass": _ppm(200.0, 2.0),
+                "intensity": 0.5,
+            },
+            {"ion_type": "b", "no": 2, "charge": 1, "theoretical_mass": 400.0, "exp_mass": shared, "intensity": 0.5},
+            {"ion_type": "y", "no": 1, "charge": 1, "theoretical_mass": 400.0001, "exp_mass": shared, "intensity": 0.5},
+            {
+                "ion_type": "y",
+                "no": 2,
+                "charge": 1,
+                "theoretical_mass": 600.0,
+                "exp_mass": _ppm(600.0, 2.0),
+                "intensity": 0.5,
+            },
         ]
         unique_df, _ = dp_calibrated_resolver(cands, mass_tolerance=20, unit_mass_tolerance="ppm", unique_peak=True)
         reuse_df, _ = dp_calibrated_resolver(cands, mass_tolerance=20, unit_mass_tolerance="ppm", unique_peak=False)
@@ -502,10 +621,8 @@ class TestDpCalibratedResolver(unittest.TestCase):
 
     def test_nonfinite_rows_dropped(self):
         cands = _b_ladder(error_ppm=3.0) + [
-            {"ion_type": "b", "no": 6, "charge": 1, "theoretical_mass": np.nan,
-             "exp_mass": 600.0, "intensity": 0.1},
-            {"ion_type": "y", "no": 7, "charge": 1, "theoretical_mass": -5.0,
-             "exp_mass": 700.0, "intensity": 0.1},
+            {"ion_type": "b", "no": 6, "charge": 1, "theoretical_mass": np.nan, "exp_mass": 600.0, "intensity": 0.1},
+            {"ion_type": "y", "no": 7, "charge": 1, "theoretical_mass": -5.0, "exp_mass": 700.0, "intensity": 0.1},
         ]
         df, dropped = dp_calibrated_resolver(cands, mass_tolerance=20, unit_mass_tolerance="ppm")
         self.assertEqual(len(df), 4)
@@ -515,9 +632,7 @@ class TestDpCalibratedResolver(unittest.TestCase):
     def test_nonfinite_intensity_does_not_poison_cost(self):
         cands = _b_ladder(error_ppm=3.0)
         cands[2]["intensity"] = np.nan
-        df, _ = dp_calibrated_resolver(
-            cands, mass_tolerance=20, unit_mass_tolerance="ppm", intensity_weight=0.5
-        )
+        df, _ = dp_calibrated_resolver(cands, mass_tolerance=20, unit_mass_tolerance="ppm", intensity_weight=0.5)
         self.assertEqual(len(df), 4)
         self.assertTrue(((df["ion_type"] == "b") & (df["no"] == 3)).any())
 

--- a/tests/unit_tests/test_matchers.py
+++ b/tests/unit_tests/test_matchers.py
@@ -78,7 +78,9 @@ class TestNearestResolver(unittest.TestCase):
         resolver_df, resolver_dropped = nearest_resolver(matched_peaks)
 
         pd.testing.assert_frame_equal(legacy_df, resolver_df)
-        self.assertEqual(legacy_dropped, resolver_dropped)
+        # ppm_error and future sc_features columns are not part of the legacy
+        # handle_multiple_matches output — only compare the shared columns.
+        pd.testing.assert_frame_equal(legacy_df, resolver_df[legacy_df.columns])
 
     def test_empty_input(self):
         """Empty candidate list returns an empty frame and zero dropped."""

--- a/tests/unit_tests/test_matchers.py
+++ b/tests/unit_tests/test_matchers.py
@@ -1,0 +1,226 @@
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from spectrum_fundamentals.annotation import annotation
+from spectrum_fundamentals.annotation.matchers import resolve_matches
+from spectrum_fundamentals.annotation.matchers.global_ransac import (
+    _resolve_residual_threshold,
+    global_ransac_resolver,
+)
+from spectrum_fundamentals.annotation.matchers.nearest import nearest_resolver
+
+
+def _ppm(theoretical_mass: float, error_ppm: float) -> float:
+    """Return an experimental mass that is ``error_ppm`` away from theoretical."""
+    return theoretical_mass * (1 + error_ppm * 1e-6)
+
+
+def _line_candidates(error_ppm: float = 3.0) -> list[dict]:
+    """Four fragment slots whose true peaks all sit on a constant ppm drift line."""
+    return [
+        {"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 200.0,
+         "exp_mass": _ppm(200.0, error_ppm), "intensity": 0.5},
+        {"ion_type": "y", "no": 1, "charge": 1, "theoretical_mass": 400.0,
+         "exp_mass": _ppm(400.0, error_ppm), "intensity": 0.7},
+        {"ion_type": "b", "no": 2, "charge": 1, "theoretical_mass": 600.0,
+         "exp_mass": _ppm(600.0, error_ppm), "intensity": 0.4},
+        {"ion_type": "y", "no": 2, "charge": 1, "theoretical_mass": 800.0,
+         "exp_mass": _ppm(800.0, error_ppm), "intensity": 0.6},
+    ]
+
+
+class TestNearestResolver(unittest.TestCase):
+    """The legacy closest-m/z resolver."""
+
+    def test_equivalent_to_handle_multiple_matches(self):
+        """nearest_resolver must reproduce handle_multiple_matches(sort_by='mass_diff') byte-for-byte."""
+        matched_peaks = [
+            {"ion_type": "b", "no": 2, "charge": 1, "exp_mass": 200, "theoretical_mass": 198, "intensity": 0.05},
+            {"ion_type": "b", "no": 2, "charge": 1, "exp_mass": 205, "theoretical_mass": 198, "intensity": 0.01},
+            {"ion_type": "y", "no": 3, "charge": 1, "exp_mass": 300, "theoretical_mass": 303, "intensity": 0.1},
+            {"ion_type": "y", "no": 3, "charge": 1, "exp_mass": 303, "theoretical_mass": 303, "intensity": 0.05},
+        ]
+        legacy_df, legacy_dropped = annotation.handle_multiple_matches(matched_peaks, sort_by="mass_diff")
+        resolver_df, resolver_dropped = nearest_resolver(matched_peaks)
+
+        pd.testing.assert_frame_equal(legacy_df, resolver_df)
+        self.assertEqual(legacy_dropped, resolver_dropped)
+
+    def test_empty_input(self):
+        """Empty candidate list returns an empty frame and zero dropped."""
+        df, dropped = nearest_resolver([])
+        self.assertTrue(df.empty)
+        self.assertEqual(dropped, 0)
+
+
+class TestResolveMatchesDispatch(unittest.TestCase):
+    """The registry dispatch function."""
+
+    def test_unknown_method_raises(self):
+        """An unregistered method name raises a helpful ValueError."""
+        with self.assertRaises(ValueError):
+            resolve_matches("does_not_exist", _line_candidates(), None, None, "PEPTIDE")
+
+    def test_dispatch_matches_direct_call(self):
+        """Dispatching forwards kwargs identically to calling the resolver directly."""
+        cands = _line_candidates()
+        via_registry, _ = resolve_matches(
+            "global_ransac", cands, None, None, "PEPTIDE", residual_threshold_ppm=5.0, random_state=0
+        )
+        direct, _ = global_ransac_resolver(cands, residual_threshold_ppm=5.0, random_state=0)
+        pd.testing.assert_frame_equal(
+            via_registry.reset_index(drop=True), direct.reset_index(drop=True)
+        )
+
+
+class TestGlobalRansacResolver(unittest.TestCase):
+    """Per-spectrum RANSAC mass-calibration matcher."""
+
+    def test_empty_and_none_candidates(self):
+        """None or empty candidates return an empty frame without fitting."""
+        for arg in (None, []):
+            df, dropped = global_ransac_resolver(arg)
+            self.assertTrue(df.empty)
+            self.assertEqual(dropped, 0)
+
+    def test_drift_recovery_and_outlier_rejection(self):
+        """The fit keeps the on-line matches and rejects peaks off the drift line."""
+        cands = _line_candidates(error_ppm=3.0)
+        noise = [
+            {"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 200.0,
+             "exp_mass": _ppm(200.0, -18.0), "intensity": 0.9},  # same slot as a real match, far off
+            {"ion_type": "y", "no": 2, "charge": 1, "theoretical_mass": 800.0,
+             "exp_mass": _ppm(800.0, 19.0), "intensity": 0.2},   # same slot, far off
+        ]
+        df, dropped = global_ransac_resolver(cands + noise, residual_threshold_ppm=5.0)
+
+        self.assertEqual(len(df), 4)  # one per slot
+        self.assertEqual(dropped, 2)  # both noise rows rejected
+        # the rejected (off-line) experimental masses must not appear
+        self.assertNotIn(round(_ppm(200.0, -18.0), 6), df["exp_mass"].round(6).tolist())
+        self.assertNotIn(round(_ppm(800.0, 19.0), 6), df["exp_mass"].round(6).tolist())
+        # diagnostic columns are exposed
+        self.assertIn("ppm_residual", df.columns)
+        self.assertIn("abs_dev_from_fit", df.columns)
+
+    def test_unique_peak_toggle(self):
+        """unique_peak controls whether one observed peak may fill several slots."""
+        shared = _ppm(800.0, 2.0)
+        cands = [
+            {"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 200.0,
+             "exp_mass": _ppm(200.0, 2.0), "intensity": 0.5},
+            {"ion_type": "y", "no": 1, "charge": 1, "theoretical_mass": 400.0,
+             "exp_mass": _ppm(400.0, 2.0), "intensity": 0.5},
+            {"ion_type": "b", "no": 2, "charge": 1, "theoretical_mass": 600.0,
+             "exp_mass": _ppm(600.0, 2.0), "intensity": 0.5},
+            # two distinct slots that matched the same observed peak
+            {"ion_type": "b", "no": 4, "charge": 1, "theoretical_mass": 800.0,
+             "exp_mass": shared, "intensity": 0.5},
+            {"ion_type": "y", "no": 7, "charge": 2, "theoretical_mass": 800.0008,
+             "exp_mass": shared, "intensity": 0.5},
+        ]
+        unique_df, _ = global_ransac_resolver(cands, residual_threshold_ppm=5.0, unique_peak=True)
+        reuse_df, _ = global_ransac_resolver(cands, residual_threshold_ppm=5.0, unique_peak=False)
+
+        # with uniqueness the shared peak is claimed by exactly one slot
+        self.assertEqual(len(unique_df), 4)
+        self.assertFalse(unique_df["exp_mass"].duplicated().any())
+        # without it, both slots keep the same peak
+        self.assertEqual(len(reuse_df), 5)
+        self.assertTrue(reuse_df["exp_mass"].duplicated().any())
+
+    def test_fallback_below_min_samples(self):
+        """Fewer valid candidates than min_samples defers to nearest."""
+        single = [{"ion_type": "b", "no": 1, "charge": 1, "theoretical_mass": 200.0,
+                   "exp_mass": _ppm(200.0, 3.0), "intensity": 0.5}]
+        df, dropped = global_ransac_resolver(single, min_samples=2)
+        self.assertEqual(len(df), 1)
+        self.assertEqual(dropped, 0)
+
+    def test_nonfinite_rows_dropped(self):
+        """NaN/inf/non-positive masses are dropped and counted in n_dropped."""
+        cands = _line_candidates(error_ppm=3.0) + [
+            {"ion_type": "b", "no": 3, "charge": 1, "theoretical_mass": np.nan,
+             "exp_mass": 300.0, "intensity": 0.1},
+            {"ion_type": "b", "no": 4, "charge": 1, "theoretical_mass": np.inf,
+             "exp_mass": 400.0, "intensity": 0.1},
+            {"ion_type": "y", "no": 5, "charge": 1, "theoretical_mass": -10.0,
+             "exp_mass": 500.0, "intensity": 0.1},
+        ]
+        df, dropped = global_ransac_resolver(cands, residual_threshold_ppm=5.0)
+        self.assertEqual(len(df), 4)  # only the four valid on-line slots survive
+        self.assertEqual(dropped, 3)
+        self.assertTrue(np.isfinite(df["theoretical_mass"]).all())
+
+    def test_inlier_floor_triggers_fallback(self):
+        """A converged fit that explains too few slots defers to nearest."""
+        cands = _line_candidates(error_ppm=2.0)
+        # replace the last slot's peak with a gross outlier so it can't be an inlier
+        cands[-1]["exp_mass"] = _ppm(800.0, 50.0)
+
+        # 3/4 slots are inliers -> 0.75; below a 0.9 floor we fall back to nearest,
+        # which fills every slot (including the outlier one).
+        strict_df, _ = global_ransac_resolver(cands, residual_threshold_ppm=5.0, min_inlier_fraction=0.9)
+        self.assertEqual(len(strict_df), 4)
+        self.assertTrue(((strict_df["ion_type"] == "y") & (strict_df["no"] == 2)).any())
+
+        # 0.75 >= 0.5 floor -> keep the RANSAC result, the outlier slot is dropped.
+        lenient_df, _ = global_ransac_resolver(cands, residual_threshold_ppm=5.0, min_inlier_fraction=0.5)
+        self.assertEqual(len(lenient_df), 3)
+        self.assertFalse(((lenient_df["ion_type"] == "y") & (lenient_df["no"] == 2)).any())
+
+    def test_full_name_preserved(self):
+        """The multifrag full_name column is carried through to the output."""
+        cands = _line_candidates(error_ppm=3.0)
+        for i, c in enumerate(cands):
+            c["full_name"] = f"frag_{i}"
+        df, _ = global_ransac_resolver(cands, residual_threshold_ppm=5.0)
+        self.assertIn("full_name", df.columns)
+
+    def test_missing_required_column_raises(self):
+        """Candidate rows missing a contract column raise ValueError."""
+        bad = [{"ion_type": "b", "no": 1, "charge": 1, "exp_mass": 200.0, "intensity": 0.5}]  # no theoretical_mass
+        with self.assertRaises(ValueError):
+            global_ransac_resolver(bad)
+
+    def test_hyperparameter_validation(self):
+        """Out-of-range hyperparameters raise ValueError before fitting."""
+        cands = _line_candidates()
+        for kwargs in (
+            {"min_samples": 1},
+            {"max_trials": 0},
+            {"min_inlier_fraction": 1.5},
+            {"min_inlier_fraction": -0.1},
+            {"residual_threshold_ppm": 0},
+            {"residual_threshold_ppm": -3.0},
+            {"residual_threshold_ppm": float("inf")},
+        ):
+            with self.subTest(**kwargs):
+                with self.assertRaises(ValueError):
+                    global_ransac_resolver(cands, **kwargs)
+
+
+class TestResidualThresholdDerivation(unittest.TestCase):
+    """Tolerance-aware default for the RANSAC inlier band."""
+
+    def test_explicit_value_wins(self):
+        self.assertEqual(_resolve_residual_threshold(8.0, 20.0, "ppm"), 8.0)
+
+    def test_derived_from_ppm_tolerance(self):
+        self.assertEqual(_resolve_residual_threshold(None, 20.0, "ppm"), 10.0)
+
+    def test_da_tolerance_uses_fixed_default(self):
+        self.assertEqual(_resolve_residual_threshold(None, 20.0, "da"), 5.0)
+
+    def test_missing_tolerance_uses_fixed_default(self):
+        self.assertEqual(_resolve_residual_threshold(None, None, None), 5.0)
+
+    def test_invalid_explicit_value_raises(self):
+        with self.assertRaises(ValueError):
+            _resolve_residual_threshold(-1.0, None, None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**PR Checklist**

- [x] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked <!-- add e.g. Closes #123 -->
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated <!-- see note below -->

**Description of changes**

Peak matching, deciding which observed peak fills each theoretical b/y fragment
slot, feeds directly into the spectral-angle and count features used for
rescoring. Until now this was a single fixed heuristic (nearest-m/z via
`handle_multiple_matches`), which is fragile when noise peaks fall inside the
tolerance window (common in low-S/N / single-cell spectra).

This PR introduces a small **pluggable resolver registry** in
`spectrum_fundamentals.annotation.matchers` and threads a `matching_method`
(plus optional `matching_method_params`) argument through `annotate_spectra`.
Four resolvers are provided:

- **`nearest`** (default), closest-m/z per fragment; **byte-identical to the
  previous `handle_multiple_matches(sort_by="mass_diff")`**, so existing behaviour
  is unchanged.
- **`global_ransac`**, per-spectrum RANSAC fit of the mass-calibration line
  `ppm ~ a + b·theoretical_mass`; picks the inlier closest to the line, correcting
  systematic drift and rejecting off-line noise.
- **`dp_ladder`**, dynamic programming over the b/y ion ladder (per-fragment m/z
  emission + inter-fragment gap-consistency + skip penalty, with hard
  monotonicity); uses the sequential ladder structure to reject noise and bridge
  missing fragments.
- **`dp_calibrated`**, combines the two: a RANSAC drift fit feeds a *de-drifted*
  emission into the ladder DP, with optional EM-style re-fit iterations.

**User impact:** none by default (`matching_method` defaults to `"nearest"`).
Opt in via the companion oktoberfest config keys.

**Technical details**

- No new dependencies, the RANSAC resolvers use `sklearn` (already a dependency);
  everything else is numpy/pandas.
- Shared DP core: `dp_calibrated` reuses `dp_ladder`'s assignment via an
  `emit_col` hook; `global_ransac` is left untouched.
- **Robustness throughout:** all hyperparameters are range-checked; non-finite or
  non-positive masses are dropped; non-finite intensities are neutralised in the
  cost. Graceful fallback chains: `dp_calibrated` → raw `dp_ladder` (if the
  calibration line is untrustworthy) → `nearest`; `global_ransac`/`dp_ladder` →
  `nearest` under their inlier/match-fraction floors. RANSAC inlier bands and the
  DP ppm scale are derived from the matching tolerance when not given.
- **Tests:** new `tests/unit_tests/test_matchers.py` (registry dispatch, all four
  resolvers, fit helpers, fallbacks, non-finite handling, hyperparameter
  validation) plus end-to-end `annotate_spectra` cases per matcher in
  `test_annotation.py`. Full unit suite passes (the pre-existing `test_percolator.py`
  `moepy` import gap is unrelated).
- **Deferred (out of scope):** Percolator features derivable from the fits
  (`mass_drift_slope/intercept`, residual MAD, …) are computed internally but not
  yet wired into the feature matrix. The crosslink path still uses the legacy
  resolver. `dp_ladder`/`dp_calibrated` deliberately do **not** consult Prosit
  predictions (they run before the spectral angle), avoiding circularity.

> Note on the docs checkbox: `docs/` here is an autodoc stub; the per-parameter
> reference lives in the resolver docstrings, and the **user-facing config option
> is documented in the companion oktoberfest PR**. Happy to add a narrative page
> if preferred.

**Additional context**

Preliminary bulk benchmark (HepG2/trypsin fraction, 1% FDR): `global_ransac` vs
`nearest` → **+2.3% peptides, −2.0% PSMs**, marginal on bulk (where `nearest` is
already near-optimal); the single-cell evaluation and entrapment-FMR control are
the real test and are still pending. Companion PR: wilhelm-lab/oktoberfest#387.
